### PR TITLE
proxy redirect to secure https connection

### DIFF
--- a/source/includes/proxy-rewrite.rst
+++ b/source/includes/proxy-rewrite.rst
@@ -7,7 +7,10 @@ Create a ``~/html/.htaccess`` file with the following content:
  DirectoryIndex disabled
  
  RewriteEngine On
- RewriteRule ^(.*) http://localhost:<yourport>/$1 [P]
+ RewriteCond %{HTTPS} !=on
+ RewriteCond %{ENV:HTTPS} !=on
+ RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [R=301,L]
+ RewriteRule (.*) http://localhost:<yourport>/$1 [P]
 
 In our example this would be:
 
@@ -16,4 +19,8 @@ In our example this would be:
  DirectoryIndex disabled
  
  RewriteEngine On
- RewriteRule ^(.*) http://localhost:9000/$1 [P]
+ RewriteCond %{HTTPS} !=on
+ RewriteCond %{ENV:HTTPS} !=on
+ RewriteRule .* https://%{SERVER_NAME}%{REQUEST_URI} [R=301,L]
+ RewriteRule (.*) http://localhost:9000/$1 [P]
+ 


### PR DESCRIPTION
Is there any reason, why not all the proxy redirects should be used to redirect to secure https as well? Since TLS is now available by default on U7