### PR TITLE
Display the authors of our lovely guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,19 +2,116 @@
 .DS_Store
 .Thumbs.db
 
-# virtualenv
-venv
-
-# Installer logs
-pip-log.txt
-pip-delete-this-directory.txt
-
-
 # ansible
 *.retry
 
 # Sphinx
 build
+*.doctree
+*.doctrees
 
 # CI
 .sshkey
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+.pytest_cache/
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule.*
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+
+# End of https://www.gitignore.io/api/python

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,13 +14,13 @@ stages:
 before_script:
   # GitLab inserts a \r for each newline into our private key. This confuses the ssh client.
   - umask 077; echo "$SSH_KEY" | tr -d '\r' > $DEPLOYMENT_SSH_KEY_PATH
-  # Dependencies
-  - pip install --quiet -r requirements.txt
 
 
 Build HTML:
   stage: build
+  image: python:3.6
   script:
+    - pip install --quiet -r requirements.txt
     - make html
   artifacts:
     paths:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ be built locally.
 ### Initial Setup
 
 ```
-$ virtualenv venv --python=python2.7
+$ virtualenv venv --python=python3.6
 $ source venv/bin/activate
 $ pip install -r requirements.txt
 ```

--- a/authorship/authorship/__init__.py
+++ b/authorship/authorship/__init__.py
@@ -28,8 +28,18 @@ class Author(SphinxDirective):
 class Authors(SphinxDirective):
     def run(self):
         env = self.state.document.settings.env
-        return generate_author_list(env.authors.get(env.docname, []))
+        authors = env.authors.get(env.docname, [])
 
+        if not authors:
+            return []
+
+        author_elems = []
+
+        for author in authors:
+            author_elems.append(nodes.Text(author))
+            author_elems.append(nodes.Text(', '))
+
+        return [nodes.Text('Written by: ')] + author_elems[:-1]
 
 # maker node later to be replaced by list of all authors
 class allauthors(nodes.General, nodes.Element):

--- a/authorship/authorship/__init__.py
+++ b/authorship/authorship/__init__.py
@@ -2,19 +2,21 @@ import itertools
 
 from docutils import nodes
 from sphinx.util.docutils import SphinxDirective
+import sphinx.addnodes as addnodes
 from docutils.parsers.rst import directives
 
 
-def bullet_list(items):
-    lst = nodes.bullet_list()
+def comma_list(nodes_):
+    elements = []
 
-    for item in items:
-        lst_item = nodes.list_item()
-        lst += lst_item
-        lst_item += nodes.paragraph(text=item)
+    if not nodes_:
+        return []
 
-    return lst
+    for node in nodes_:
+        elements.append(node)
+        elements.append(nodes.Text(', '))
 
+    return elements[:-1]
 
 class Author(SphinxDirective):
     required_arguments = 1
@@ -37,13 +39,7 @@ class Authors(SphinxDirective):
         if not authors:
             return []
 
-        author_elems = []
-
-        for author in authors:
-            author_elems.append(nodes.Text(author))
-            author_elems.append(nodes.Text(', '))
-
-        return [nodes.Text('Written by: ')] + author_elems[:-1]
+        return [nodes.Text('Written by: ')] + comma_list(nodes.Text(a) for a in authors)
 
 # maker node later to be replaced by list of all authors
 class allauthors(nodes.General, nodes.Element):
@@ -69,9 +65,37 @@ def purge_authors(app, env, docname):
 def process_authorlists(app, doctree, fromdocname):
     env = app.builder.env
     authors = set(itertools.chain(*[authors for authors in env.authors.values()]))
+    guides_by_author = {
+        a: set(g for g, guide_authors in env.authors.items() if a in guide_authors)
+        for a in authors
+    }
 
     for node in doctree.traverse(allauthors):
-        node.replace_self([bullet_list(authors)])
+        lst = nodes.bullet_list()
+
+        for author in authors:
+            lst_item = nodes.list_item()
+            lst += lst_item
+            lst_item += addnodes.compact_paragraph(text=author)
+
+            lst_item += nodes.raw('', '<br>', format='html')
+
+            links = []
+
+            for guide in guides_by_author[author]:
+                # I can't figure out a way to get the link and title from a page name..
+                link = guide + '.html'
+                title = guide.partition('_')[2].title()
+
+                link_wrapper = addnodes.compact_paragraph()
+                link_wrapper += nodes.reference('', '', nodes.Text(title), internal=True, refuri=link, anchorname='')
+
+                links.append(link_wrapper)
+
+            for n in comma_list(links):
+                lst_item += n
+
+        node.replace_self([lst])
 
 
 def setup(app):

--- a/authorship/authorship/__init__.py
+++ b/authorship/authorship/__init__.py
@@ -5,11 +5,15 @@ from sphinx.util.docutils import SphinxDirective
 from docutils.parsers.rst import directives
 
 
-def generate_author_list(authors):
-    return [
-        nodes.Text(a, a)
-        for a in authors
-    ]
+def bullet_list(items):
+    lst = nodes.bullet_list()
+
+    for item in items:
+        lst_item = nodes.list_item()
+        lst += lst_item
+        lst_item += nodes.paragraph(text=item)
+
+    return lst
 
 
 class Author(SphinxDirective):
@@ -67,7 +71,7 @@ def process_authorlists(app, doctree, fromdocname):
     authors = set(itertools.chain(*[authors for authors in env.authors.values()]))
 
     for node in doctree.traverse(allauthors):
-        node.replace_self(generate_author_list(authors))
+        node.replace_self([bullet_list(authors)])
 
 
 def setup(app):

--- a/authorship/authorship/__init__.py
+++ b/authorship/authorship/__init__.py
@@ -1,0 +1,76 @@
+import itertools
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+from docutils.parsers.rst import directives
+
+
+def generate_author_list(authors):
+    return [
+        nodes.Text(a, a)
+        for a in authors
+    ]
+
+
+class Author(SphinxDirective):
+    required_arguments = 1
+    final_argument_whitespace = True
+
+    def run(self):
+        env = self.state.document.settings.env
+
+        env.authors.setdefault(env.docname, [])
+        env.authors[env.docname].append(self.arguments[0])
+
+        return []
+
+
+class Authors(SphinxDirective):
+    def run(self):
+        env = self.state.document.settings.env
+        return generate_author_list(env.authors.get(env.docname, []))
+
+
+# maker node later to be replaced by list of all authors
+class allauthors(nodes.General, nodes.Element):
+    pass
+
+
+class AllAuthors(SphinxDirective):
+    def run(self):
+        return [allauthors('')]
+
+
+def builder_inited(app):
+    app.builder.env.authors = {}
+
+
+def purge_authors(app, env, docname):
+    if not hasattr(env, 'authors'):
+        return
+
+    env.authors.pop(docname, None)
+
+
+def process_authorlists(app, doctree, fromdocname):
+    env = app.builder.env
+    authors = set(itertools.chain(*[authors for authors in env.authors.values()]))
+
+    for node in doctree.traverse(allauthors):
+        node.replace_self(generate_author_list(authors))
+
+
+def setup(app):
+    app.add_node(allauthors)
+
+    directives.register_directive('author', Author)
+    directives.register_directive('authors', Authors)
+    directives.register_directive('allauthors', AllAuthors)
+
+    app.connect('builder-inited', builder_inited)
+    app.connect('env-purge-doc', purge_authors)
+    app.connect('doctree-resolved', process_authorlists)
+
+    return {
+        'version': '1.0.0',
+    }

--- a/authorship/setup.py
+++ b/authorship/setup.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+setup(
+    name = 'authorship',
+    version = '1.0.0',
+    author = 'uberspace.de',
+    author_email = 'hallo@uberspace.de',
+    packages = find_packages(),
+    install_requires = [
+    ],
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-Sphinx==1.7.*
+# replace with 1.7.3 once released
+git+git://github.com/sphinx-doc/sphinx@b5ddc8c6977ac964e3ba4a2eb4647decdc742f4f
 sphinx-rtd-theme==0.2.*
 sphinx-autobuild==0.7.*
 feedgen==0.6.1
+./authorship

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -75,3 +75,8 @@ nav li {
 .sidebar img {
   max-height: 150px;
 }
+
+/* separator before hall of fame */
+.toctree-l1:last-child {
+  margin-top: 10px;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -32,7 +32,9 @@ import sphinx_rtd_theme
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = [
+  'authorship',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/source/contributors.rst
+++ b/source/contributors.rst
@@ -1,5 +1,0 @@
-############
-Contributors
-############
-
-.. allauthors::

--- a/source/contributors.rst
+++ b/source/contributors.rst
@@ -1,0 +1,5 @@
+############
+Contributors
+############
+
+.. allauthors::

--- a/source/guide_etherpad.rst
+++ b/source/guide_etherpad.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: ezzra <ezra@posteo.de>
+.. author:: ezzra <ezra@posteo.de>
 .. highlight:: console
 
 #############
@@ -225,3 +225,5 @@ Then you need to restart the service daemon, so the new code is used by the webs
 ----
 
 Tested with Etherpad Lite 1.6.3 and Uberspace 7.1.1 
+
+.. authors::

--- a/source/guide_ghost.rst
+++ b/source/guide_ghost.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: Uberspace <hallo@uberspace.de>
+.. author:: Uberspace <hallo@uberspace.de>
 .. highlight:: console
 
 .. sidebar:: Logo
@@ -238,3 +238,5 @@ If it's not in state RUNNING, check your configuration.
 ----
 
 Tested with Ghost 1.22.1, Uberspace 7.1.1
+
+.. authors::

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: Uberspace <hallo@uberspace.de>
+.. author:: Uberspace <hallo@uberspace.de>
 .. highlight:: console
 
 .. sidebar:: Logo
@@ -174,3 +174,5 @@ version is available, repeat the "Installation" step followed by ``supervisorctl
 ----
 
 Tested with Gitea 1.4.0, Uberspace 7.1.3
+
+.. authors::

--- a/source/guide_jingo.rst
+++ b/source/guide_jingo.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: ezzra <ezra@posteo.de>
+.. author:: ezzra <ezra@posteo.de>
 .. highlight:: console
 
 #####
@@ -256,3 +256,5 @@ In the end you need to restart the service daemon, so the new code is used by th
 ----
 
 Tested with Jingo 1.8.5, Uberspace 7.1.1
+
+.. authors::

--- a/source/guide_lychee.rst
+++ b/source/guide_lychee.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: TheForcer <25257144+TheForcer@users.noreply.github.com>
+.. author:: TheForcer <25257144+TheForcer@users.noreply.github.com>
 .. highlight:: console
 
 .. sidebar:: Logo
@@ -90,3 +90,5 @@ If a new version is available, ``cd`` to your Lychee folder and do a simple ``gi
 ----
 
 Tested with Lychee 3.1.6, Uberspace 7.1.1
+
+.. authors::

--- a/source/guide_minim.rst
+++ b/source/guide_minim.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: minim <38093214+minim-one@users.noreply.github.com>
+.. author:: minim <38093214+minim-one@users.noreply.github.com>
 .. highlight:: console
 
 .. sidebar:: Logo
@@ -113,3 +113,5 @@ If everything works alright you can delete your ``minim-backup`` and the ``confi
 ----
 
 Tested with minim - Blog 0.5.0.1 and minim - Wiki 0.1.0.1, Uberspace 7.1.1
+
+.. authors::

--- a/source/guide_wallabag.rst
+++ b/source/guide_wallabag.rst
@@ -156,3 +156,5 @@ If there is a new version available, you can get the code using git:
 ----
 
 Tested with Wallabag 2.3.2 and Uberspace 7.1.2
+
+.. authors::

--- a/source/guide_wordpress.rst
+++ b/source/guide_wordpress.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: Uberspace <hallo@uberspace.de>
+.. author:: Uberspace <hallo@uberspace.de>
 .. highlight:: console
 
 .. sidebar:: Logo
@@ -93,3 +93,5 @@ By default, WordPress `automatically updates`_ itself to the latest stable minor
 ----
 
 Tested with WordPress 4.9.5, Uberspace 7.1.2
+
+.. authors::

--- a/source/hall_of_fame.rst
+++ b/source/hall_of_fame.rst
@@ -1,0 +1,9 @@
+###############
+👑 Hall of Fame
+###############
+
+Most of the guides in our sweet little laboratory are written by regular users
+(just like you!). While we occasionally hand out goodies for new guides or
+substantial edits, we'd like to additionally thank those users here publicly.
+
+.. allauthors::

--- a/source/index.rst
+++ b/source/index.rst
@@ -26,4 +26,5 @@ Thank you and have fun experimenting!
    :maxdepth: 1
    :glob:
 
+   contributors
    guide_*

--- a/source/index.rst
+++ b/source/index.rst
@@ -26,5 +26,5 @@ Thank you and have fun experimenting!
    :maxdepth: 1
    :glob:
 
-   contributors
    guide_*
+   hall_of_fame


### PR DESCRIPTION
fixes #67 

- upgrade to py3
- upgrade sphinx to a dev version because of https://github.com/sphinx-doc/sphinx/commit/5ff7bc6dc6496080c569b56b8551f0d5b92986d3
- add authors to bottom of each guide
- add "hall of fame" listing all authors

TODO:
- [x] add title to contributors on each guide
- [x] properly format contributors on each guide
- [ ] "Contributors" page
  - [x] rename to "Hall of Fame"
  - [x] add fluffy "THANK YOU! :heart:" text
  - [x] give each contributor their own line
  - [x] list guides each person has contributed to
  - [ ] remove `hallo@uberspace.de`
- [ ] make up our minds about additional data like emails and websites. Remove everything else and properly parse/link the remaining. I suggest optional websites.