### PR TITLE
wrap logo–check in jQuery ready function

### DIFF
--- a/source/_static/js/custom.js
+++ b/source/_static/js/custom.js
@@ -1,32 +1,28 @@
-var app = {
+$(function() {
 
-    check_logo_height: function() {
-        var logo = $('div[itemprop="articleBody"] > .sidebar')
-        var hr = $('div[itemprop="articleBody"] > .section > hr')
-        var logo_end = 0
-        var hr_position = 0
-        if (logo.length) {
-            logo_end = logo.offset().top + logo.outerHeight();
-        }
-        if (hr.length) {
-            hr_position = hr.offset().top;
-        }
-        // console.log('[logo] ' + logo_end + " → " + hr_position);
-        if (logo_end > hr_position) {
-            var margin_top = parseInt(hr.css('margin-top'), 10)
-            var margin_bottom = parseInt(hr.css('margin-bottom'), 10)
-            var offset = Math.ceil((logo_end - hr_position) / 2)
-            hr.css('margin-top', (margin_top + offset) + 'px');
-            hr.css('margin-bottom', (margin_bottom + offset) + 'px');
-            console.log( '[logo] pushed first break down by ' + (offset * 2));
-        }
-    },
-
-    init: function() {
-        console.log('UberLab launched…');
-        app.check_logo_height();
+  function check_logo_height() {
+    var logo = $('div[itemprop="articleBody"] > .sidebar');
+    var hr = $('div[itemprop="articleBody"] > .section > hr');
+    var logo_end = 0;
+    var hr_position = 0;
+    if (logo.length) {
+      logo_end = logo.offset().top + logo.outerHeight();
     }
+    if (hr.length) {
+      hr_position = hr.offset().top;
+    }
+    console.log('[logo] ' + logo_end + " vs " + hr_position)
+    if (logo_end > hr_position) {
+      var margin_top = parseInt(hr.css('margin-top'), 10);
+      var margin_bottom = parseInt(hr.css('margin-bottom'), 10);
+      var offset = Math.ceil((logo_end - hr_position) / 2);
+      hr.css('margin-top', margin_top + offset + 'px');
+      hr.css('margin-bottom', margin_bottom + offset + 'px');
+      console.log('[logo] pushed first break down by ' + offset * 2);
+    }
+  };
 
-}
+  console.log('UberLab launched…');
+  check_logo_height();
 
-app.init()
+});


### PR DESCRIPTION
I can't reproduce https://github.com/Uberspace/lab/issues/89 locally, but it seems, that the function call fails (since `UberLab launched…` is always printed to the console). So… I wrapped the check in a ready function :crossed_fingers: 