### PR TITLE
:bento: use rocket icon for guides bullet

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -123,7 +123,9 @@ nav li {
 }
 
 #hall-of-fame ol > li > ul:before {
-    content: '→ ';
+    content: url(../images/icn-rocket.svg);
+    width: 23px;
+    height: 15px;
 }
 
 #hall-of-fame ol > li > ul > li {


### PR DESCRIPTION
Use little rocket icons as bullets in front of the guides in the _Hall of Fame_.