### PR TITLE
Fix Nextcloud cron script path and log script output

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -76,7 +76,7 @@ Add the following cronjob to your crontab_:
 
 ::
 
- *  *  *  *  * php -f $HOME/html/cron.php
+ *  *  *  *  * php -f /var/www/virtual/$USER/html/cron.php
 
 Memcaching
 ----------

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -76,7 +76,7 @@ Add the following cronjob to your crontab_:
 
 ::
 
- *  *  *  *  * php -f /var/www/virtual/$USER/html/cron.php
+ *  *  *  *  * php -f /var/www/virtual/$USER/html/cron.php > $HOME/logs/nextcloud-cron.log 2>&1
 
 Memcaching
 ----------


### PR DESCRIPTION
The current guide for Nextcloud uses a wrong path for the cron script under `$HOME` instead of the installation directory `/var/www/virtual/$USER/html/`. Commit 654abaa fixes this.

Additionally commit dd70a51 logs the output of the cron script to `$HOME/logs/nextcloud-cron.log` which might be useful for maintenance and debugging.