### PR TITLE
Add missing rst markup to display author at the end of the Kirby guide

### DIFF
--- a/source/guide_kirby.rst
+++ b/source/guide_kirby.rst
@@ -150,3 +150,5 @@ If you've enabled the cache, you might need to empty the cache directory to be s
 ----
 
 Tested with Kirby 2.5.10 and Uberspace 7.1.5
+
+.. authors::


### PR DESCRIPTION
Thanks for merging the Kirby guide! 

I noticed the rst markup for the author display at the end of the guide is missing. This feature was introduced when the guide was already in review/updated and I missed that. 