### PR TITLE
Rename sectionauthor variable to author in Kirby guide

### DIFF
--- a/source/guide_kirby.rst
+++ b/source/guide_kirby.rst
@@ -1,4 +1,4 @@
-.. sectionauthor:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <uberlab@danielkratz.com>
 .. highlight:: console
 
 .. sidebar:: Logo


### PR DESCRIPTION
Sorry, I also missed that you renamed the sectionauthor variable to author. Hadn't tested it because of my outdated local build environment. Sorry about that, updated everything. 🙈