### PR TITLE
We just tested it wordpress 4.9.6

### DIFF
--- a/source/guide_wordpress.rst
+++ b/source/guide_wordpress.rst
@@ -92,6 +92,6 @@ By default, WordPress `automatically updates`_ itself to the latest stable minor
 
 ----
 
-Tested with WordPress 4.9.5, Uberspace 7.1.2
+Tested with WordPress 4.9.6, Uberspace 7.1.2
 
 .. authors::


### PR DESCRIPTION
I don't know if this is worth updating for minor point releases but for what it's worth, we just tested it with 4.9.6.