### PR TITLE
Fix Typo 'diretory' -> 'directory'

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -85,7 +85,7 @@ Since Gitea uses its own webserver, you need to find a free port and bind your a
 Change the configuration
 ------------------------
 
-You need to create a custom diretory
+You need to create a custom directory
 
 ::
 


### PR DESCRIPTION
Fix a typo in the Gitea documentation.