### PR TITLE
Gitea: Bump Version and add SSH key management through gitea

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -57,7 +57,7 @@ make sure that the file can be executed.
 ::
 
   [isabell@stardust ~]$ mkdir ~/gitea
-  [isabell@stardust ~]$ wget -O gitea/gitea https://github.com/go-gitea/gitea/releases/download/v1.4.2/gitea-1.4.2-linux-amd64
+  [isabell@stardust ~]$ wget -O gitea/gitea https://github.com/go-gitea/gitea/releases/download/v1.4.3/gitea-1.4.3-linux-amd64
   Resolving dl.gitea.io (github.com)... 2400:cb00:2048:1::681b:8e9b, 2400:cb00:2048:1::681b:8f9b, 104.27.142.155, ...
   Connecting to dl.gitea.io (github.com)|2400:cb00:2048:1::681b:8e9b|:443... connected.
   HTTP request sent, awaiting response... 200 OK
@@ -68,7 +68,7 @@ make sure that the file can be executed.
 
   2018-03-25 18:36:36 (8.72 MB/s) - gitea/gitea’ saved [52960072/52960072]
   [isabell@stardust ~]$ sha256sum gitea/gitea
-  e14e54f334ce022d2026d0801da1ed1bf3bcba751b16fb290bae4d10d14482e9  gitea/gitea
+  fe60fca294baa24fe4862bbcfe29c92d5a8a883a48aadb80f3a1270cf5de9bd4  gitea/gitea
   [isabell@stardust ~]$ chmod +x gitea/gitea
   [isabell@stardust ~]$
 
@@ -175,6 +175,6 @@ version is available, repeat the "Installation" step followed by ``supervisorctl
 
 ----
 
-Tested with Gitea 1.4.0, Uberspace 7.1.3
+Tested with Gitea 1.4.3, Uberspace 7.1.3
 
 .. authors::

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -156,13 +156,30 @@ Point your browser to your gitea URL and finish the installation.
 
 .. note:: Using the same public key for Gitea and your Uberspace will prevent you from logging in with this key via SSH. Login via password still works as expected, you can use the Dashboard_ to manage your keys.
 
+SSH key management through gitea
+================================
+
+If you want that gitea manages SSH authorized_keys you can do:
+
+::
+
+ [isabell@stardust ~]$ ln -s ~/.ssh ~/gitea/
+
+Add your key in gitea and then change the line in ``.ssh/authorized_keys`` to the following:
+
+::
+
+ command="if [ -t 0 ]; then bash; elif [[ $SSH_ORIGINAL_COMMAND =~ ^(scp|rsync|mysqldump).* ]]; then eval $SSH_ORIGINAL_COMMAND; else /home/<username>/gitea/gitea serv key-1 --config='/home/<username>/gitea/custom/conf/app.ini'; fi",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ssh-...
+
+.. warning:: Replace ``<username>`` with your username and put your public key after ``ssh-``!
+
 Updates
 =======
 
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
 Check Gitea's `releases <https://github.com/go-gitea/gitea/releases/latest>`_ for the latest version. If a newer
-version is available, repeat the "Installation" step followed by ``supervisorctl restart gitea`` to restart gitea.
+version is available, stop daemon by ``supervisorctl stop gitea`` and repeat the "Installation" step followed by ``supervisorctl start gitea`` to restart gitea.
 
 .. _Gitea: https://gitea.io/en-US/
 .. _Gogs: https://gogs.io


### PR DESCRIPTION
`supervisorctl stop gitea` is needed to be able to overwrite the executable.