### PR TITLE
Add information for syncing with macOS

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -85,7 +85,7 @@ Since Gitea uses its own webserver, you need to find a free port and bind your a
 Change the configuration
 ------------------------
 
-You need to create a custom diretory
+You need to create a custom directory
 
 ::
 

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -127,6 +127,23 @@ Nextcloud will complain about your HSTS settings in the admin interface.
 
 At the moment it is not possible to change the HSTS settings, as mentioned in the `manual <https://manual.uberspace.de/en/web-security.html>`_.
 
+Syncing with macOS
+------------------
+
+If you plan on using the contacts and calendars apps and syncing them with macOS you should add some HTTP redirects. 
+MacOS expects to find the CalDAV and CardDAV endpoints with specific URLs and thus we need to add some webserver configuration to
+make the URLs work as expected.
+Edit /var/www/virtual/$USER/html/.htaccess and add the following two lines
+
+::
+
+ Redirect 301 /.well-known/carddav /remote.php/dav
+ Redirect 301 /.well-known/caldav /remote.php/dav
+
+::
+
+Follow the instructions in the NextCloud `manual <https://docs.nextcloud.com/server/13/user_manual/pim/sync_ios.html>`_ to set up the accounts on your devices.
+
 Updates
 =======
 


### PR DESCRIPTION
At least starting with mac OS El Capitan the syncing with CardDAV and CalDAV
seem to require specific URLs.
See also: https://github.com/sabre-io/Baikal/issues/401