### PR TITLE
Fix build warnings

### DIFF
--- a/source/guide_eqdkp-plus.rst
+++ b/source/guide_eqdkp-plus.rst
@@ -6,9 +6,9 @@
   .. image:: _static/images/eqdkp-plus.svg
       :align: center
 
-#########
+##########
 EQdkp Plus
-#########
+##########
 
 EQdkp-Plus_ is an open source Content Management System (CMS) and Guild Management System in PHP and distributed unter the AGPLv3 licence. 
 It is focused on supporting guilds and clans playing online games, especially MMORPGs. Therefore it brings tools for planning raids or distributing loot or points like DKP (Dragon Kill Points).
@@ -66,6 +66,7 @@ You will need to enter the following information:
    [isabell@stardust html]$ openssl rand -base64 32
    SuperSecretPassword
    [isabell@stardust html]$ 
+
   * Make additional settings like setting first day of week etc. The script path setting is automatically detected and only needs to be changed if the detection will fail. The script path is the subfolder of your domain. If you follow this tutorial, it is ``/``.
   * Administrator username and password: choose a username (maybe not *admin*) and a strong password for the admin user
 

--- a/source/guide_kirby.rst
+++ b/source/guide_kirby.rst
@@ -73,7 +73,7 @@ To install the Kirby Starterkit_ into your `document root`_, you just need to us
 That's all the magic. If you visit your previously set up domain you should see a working website with demo contents from the Starterkit. 
 
 Configuration
-============
+=============
 
 When you're ready to launch your website with Kirby you need to purchase a license_. To use your license edit the configuration file ``~/html/site/config/config.php`` and fill in your licence key.
 
@@ -85,7 +85,7 @@ When you're ready to launch your website with Kirby you need to purchase a licen
 
 
 Best practices
-============
+==============
 
 If you want to avoid the demo code and contents of the Kirby Starterkit, there is a minimal setup available known as Plainkit_. You can install it by appending the kit parameter to the install command ``kirby install html --kit plainkit``. However, the use is only recommended for users who are already familiar with Kirby. 
 

--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -56,7 +56,7 @@ Create ``~/html/.htaccess`` with the following content:
 
 .. warning:: Replace ``<yourport>`` with your port!
 
-.. code-block:: .htaccess
+.. code-block:: apacheconf
 
  RewriteEngine On
  RewriteRule (.*) http://localhost:<yourport>/$1 [P]
@@ -64,7 +64,7 @@ Create ``~/html/.htaccess`` with the following content:
 
 In our example this would be:
 
-.. code-block:: .htaccess
+.. code-block:: apacheconf
 
  RewriteEngine On
  RewriteRule (.*) http://localhost:9000/$1 [P]

--- a/source/guide_ttrss.rst
+++ b/source/guide_ttrss.rst
@@ -93,14 +93,15 @@ Open the URL and set the Database settings to your MySQL hostname, username and 
 
 Under other settings the domain https://isabell.uber.space should be shown.
 Now click on `Test Configuration`. If everything worked you should see the messages
+
  * Configuration check succeeded.
  * Database test succeeded.
 
 Click on `Initialize Database`. After that the generated configuration will be shown. Click on `Save configuration` to save it.
 If you need to change it afterwards you will find it under ``~/html/config-php``.
 
- Configure users
- ---------------
+Configure users
+---------------
 
  Now you can reach Tiny Tiny RSS under https://isabell.uber.space for the first time. Log in with 
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,6 +1,6 @@
-#########
+##########
 ⚛️ Uberlab
-#########
+##########
 
 .. image:: _static/images/atom.svg
 


### PR DESCRIPTION
There are some syntactic errors in the docs that lead to 11 warnings.
One error even leads to a missing headline.
This commit fixes all the warnings.