### PR TITLE
Fix wrong shape-outside for atom image

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -81,7 +81,7 @@ nav li {
     float: right;
     width: 30%;
     height: 30%;
-    shape-outside: url(/_images/atom.svg);
+    shape-outside: url(/en/_images/atom.svg);
     shape-margin: 1em;
 }
 


### PR DESCRIPTION
The atom image on the front page is rendered in front of the text because the file specified as shape-outside does not exist. Adding `/en/` as url prefix resolves this issue.

Before:
![lab](https://user-images.githubusercontent.com/10050780/45974740-8e258c00-c042-11e8-916a-e66b29586a2b.PNG)

After:
![grafik](https://user-images.githubusercontent.com/10050780/45974887-fffdd580-c042-11e8-8521-4c0943c8b7dc.png)