### PR TITLE
Add windows venv folder gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,6 +99,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+Scripts/
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
The built-in `venv `module of python3 creates a folder called Scripts, this is currently not ignored.
This PR adds the directory to the environment ignores.