### PR TITLE
add a guide for prometheus

### DIFF
--- a/source/_static/images/prometheus.svg
+++ b/source/_static/images/prometheus.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   width="115.333px"
+   height="114px"
+   viewBox="0 0 115.333 114"
+   enable-background="new 0 0 115.333 114"
+   xml:space="preserve"
+   sodipodi:docname="prometheus_logo_orange.svg"
+   inkscape:version="0.92.1 r15371"><metadata
+     id="metadata4495"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+     id="defs4493" /><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1484"
+     inkscape:window-height="886"
+     id="namedview4491"
+     showgrid="false"
+     inkscape:zoom="5.2784901"
+     inkscape:cx="60.603667"
+     inkscape:cy="60.329656"
+     inkscape:window-x="54"
+     inkscape:window-y="7"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><g
+     id="Layer_2" /><path
+     style="fill:#e6522c;fill-opacity:1"
+     inkscape:connector-curvature="0"
+     id="path4486"
+     d="M 56.667,0.667 C 25.372,0.667 0,26.036 0,57.332 c 0,31.295 25.372,56.666 56.667,56.666 31.295,0 56.666,-25.371 56.666,-56.666 0,-31.296 -25.372,-56.665 -56.666,-56.665 z m 0,106.055 c -8.904,0 -16.123,-5.948 -16.123,-13.283 H 72.79 c 0,7.334 -7.219,13.283 -16.123,13.283 z M 83.297,89.04 H 30.034 V 79.382 H 83.298 V 89.04 Z M 83.106,74.411 H 30.186 C 30.01,74.208 29.83,74.008 29.66,73.802 24.208,67.182 22.924,63.726 21.677,60.204 c -0.021,-0.116 6.611,1.355 11.314,2.413 0,0 2.42,0.56 5.958,1.205 -3.397,-3.982 -5.414,-9.044 -5.414,-14.218 0,-11.359 8.712,-21.285 5.569,-29.308 3.059,0.249 6.331,6.456 6.552,16.161 3.252,-4.494 4.613,-12.701 4.613,-17.733 0,-5.21 3.433,-11.262 6.867,-11.469 -3.061,5.045 0.793,9.37 4.219,20.099 1.285,4.03 1.121,10.812 2.113,15.113 C 63.797,33.534 65.333,20.5 71,16 c -2.5,5.667 0.37,12.758 2.333,16.167 3.167,5.5 5.087,9.667 5.087,17.548 0,5.284 -1.951,10.259 -5.242,14.148 3.742,-0.702 6.326,-1.335 6.326,-1.335 l 12.152,-2.371 c 10e-4,-10e-4 -1.765,7.261 -8.55,14.254 z" /></svg>

--- a/source/guide_prometheus.rst
+++ b/source/guide_prometheus.rst
@@ -105,7 +105,7 @@ Create the file ``~/etc/services.d/prometheus.ini`` with the following content:
     --config.file=/home/isabell/etc/prometheus/prometheus.yml
     --storage.tsdb.path=/home/isabell/var/lib/prometheus/
     --storage.tsdb.retention=15d
-    --web.external-url=https://isabell.stardust.uberspace.de/prometheus/
+    --web.external-url=https://isabell.stardust.uberspace.de/
     --web.route-prefix=/
   autostart=yes
   autorestart=yes
@@ -120,7 +120,7 @@ In our example this would be:
     --config.file=/home/isabell/etc/prometheus/prometheus.yml
     --storage.tsdb.path=/home/isabell/var/lib/prometheus/
     --storage.tsdb.retention=15d
-    --web.external-url=https://isabell.stardust.uberspace.de/prometheus/
+    --web.external-url=https://isabell.stardust.uberspace.de/
     --web.route-prefix=/
   autostart=yes
   autorestart=yes

--- a/source/guide_prometheus.rst
+++ b/source/guide_prometheus.rst
@@ -1,6 +1,6 @@
 .. highlight:: console
 
-.. author:: Malte Krupa <nafn.de>
+.. author:: Malte Krupa <http://nafn.de>
 
 .. sidebar:: About
 
@@ -54,7 +54,7 @@ Installation
 Step 1
 ------
 
-Find the latest version of prometheus_ for linux from the website https://prometheus.io/download, download and extract it and enter the newly created directory:
+Find the latest version of prometheus_ for the operating system ``linux`` and the architecture ``amd64`` from the `download page <https://prometheus.io/download>`_, download and extract it and enter the extracted directory:
 
 ::
 
@@ -66,7 +66,7 @@ Find the latest version of prometheus_ for linux from the website https://promet
 Step 2
 ------
 
-Move the binary to ``~/bin`` and move the configuration file to ``~/etc/prometheus``.
+Move the binary to ``~/bin`` and the configuration file to ``~/etc/prometheus``.
 
 ::
 
@@ -94,8 +94,25 @@ Setup daemon
 
 Create the file ``~/etc/services.d/prometheus.ini`` with the following content:
 
+.. warning:: Replace ``<yourport>`` with your port!
+
 .. code-block:: ini
-  :emphasize-lines: 2
+  :emphasize-lines: 3
+
+  [program:prometheus]
+  command=/home/isabell/bin/prometheus
+    --web.listen-address=localhost:<yourport>
+    --config.file=/home/isabell/etc/prometheus/prometheus.yml
+    --storage.tsdb.path=/home/isabell/var/lib/prometheus/
+    --storage.tsdb.retention=15d
+    --web.external-url=https://isabell.stardust.uberspace.de/prometheus/
+    --web.route-prefix=/
+  autostart=yes
+  autorestart=yes
+
+In our example this would be:
+
+.. code-block:: ini
 
   [program:prometheus]
   command=/home/isabell/bin/prometheus
@@ -141,11 +158,16 @@ Best practices
 Security
 --------
 
-As described by the prometheus security documentation, it's presumed that untrusted users have access to the prometheus HTTP endpoint and logs.
+To quote the `prometheus security documentation <https://prometheus.io/docs/operating/security/#prometheus>`_:
 
-It is also presumed that only trusted users have the ability to change the command line, configuration file, rule files and other aspects of the runtime environment of Prometheus and other components.
+::
 
-Further reading: https://prometheus.io/docs/operating/security/#prometheus
+  It's presumed that untrusted users have access to the prometheus HTTP
+  endpoint and logs.
+
+  It is also presumed that only trusted users have the ability to change
+  the command line, configuration file, rule files and other aspects of
+  the runtime environment of Prometheus and other components.
 
 .. _Prometheus: https://prometheus.io/
 .. _supervisord: https://manual.uberspace.de/en/daemons-supervisord.html

--- a/source/guide_prometheus.rst
+++ b/source/guide_prometheus.rst
@@ -169,6 +169,10 @@ To quote the `prometheus security documentation <https://prometheus.io/docs/oper
   the command line, configuration file, rule files and other aspects of
   the runtime environment of Prometheus and other components.
 
+As stated in the security documentation, it is ok to make prometheus reachable for everyone as long as only you are able to change the configuration files and the CLI arguments.
+
+If this is something you do not want to do, you could hide it behind a basic auth. But keep in mind that by doing so, all other users of your uberspace host would still be able to access the prometheus webinterface!
+
 .. _Prometheus: https://prometheus.io/
 .. _supervisord: https://manual.uberspace.de/en/daemons-supervisord.html
 


### PR DESCRIPTION
Closes #288 

I'd be happy to change the network part of the guide to align it with the `web-backends` branch. I'm not sure if this should be done now (in this PR) or afterwards (in another PR with `web-backends` branch as target).