### PR TITLE
Add make.bat for windows machines

### DIFF
--- a/make.bat
+++ b/make.bat
@@ -1,0 +1,36 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+set SPHINXPROJ=Uberspace7lab
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/make.bat
+++ b/make.bat
@@ -1,5 +1,13 @@
 @ECHO OFF
 
+echo.Hi there, dear windows user. As we are primiarily linux/mac people
+echo.at uberspace, please note that building the lab on windows is not
+echo.directly supported. In case something breaks, feel free to open a
+echo.pull request fixing the problem, but don't hold your breath for a
+echo.fix on our side.
+echo.
+echo.Thank you!
+
 pushd %~dp0
 
 REM Command file for Sphinx documentation


### PR DESCRIPTION
This adds a make.bat to be able to build the Sphinx HTML on Windows. The original file comes from Sphinx directly (see [here](http://howto.nspx.ca/how-to-sphinx.html#using-sphinx-autobuild)) and has been adjusted for Uberlab. 

In a virtual environment, run ``make.bat html`` just like you would do on Linux:
```
(venv) PS R:\uberlab> .\make.bat html
[...]
The HTML pages are in build\html.
(venv) PS R:\uberlab> 
```