### PR TITLE
Enable `extlinks` extension

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -87,7 +87,7 @@ extlinks = {
         'https://manual.uberspace.de/%s.html',
         ''
     ),
-    'manualanchor': (
+    'manual_anchor': (
         'https://manual.uberspace.de/%s',
         ''
     ),

--- a/source/conf.py
+++ b/source/conf.py
@@ -33,7 +33,8 @@ import sphinx_rtd_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-  'authorship',
+    'authorship',
+    'sphinx.ext.extlinks',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -78,24 +79,38 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+# Configure the `extlinks` extension to handle the `manual` directive.
+# By setting an empty string as the second tuple element, the display text
+# is the same as the target by default.
+extlinks = {
+    'manual': (
+        'https://manual.uberspace.de/%s.html',
+        ''
+    ),
+    'manualanchor': (
+        'https://manual.uberspace.de/%s',
+        ''
+    ),
+}
+
 
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
-  'display_version': False,
-  'navigation_depth': 2,
-  'collapse_navigation': True
+    'display_version': False,
+    'navigation_depth': 2,
+    'collapse_navigation': True
 }
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_last_updated_fmt = '%b %d, %Y'
 html_context = {
-  'css_files': ['_static/css/custom.css'],
-  'display_github': True,
-  'github_user': 'Uberspace',
-  'github_repo': 'lab',
-  'github_version': 'master',
-  'conf_py_path': '/source/'
+    'css_files': ['_static/css/custom.css'],
+    'display_github': True,
+    'github_user': 'Uberspace',
+    'github_repo': 'lab',
+    'github_version': 'master',
+    'conf_py_path': '/source/'
 }
 html_show_copyright = False
 html_favicon = '_static/favicon.ico'

--- a/source/guide_akaunting.rst
+++ b/source/guide_akaunting.rst
@@ -20,8 +20,8 @@ The software is based on top of the Laravel_ framework and therefore written in 
 .. note:: For this guide you should be familiar with the basic concepts of
 
   * PHP_
-  * MySQL_
-  * domains_
+  * :manual:`MySQL <database-mysql>`
+  * :manual:`domains <web-domains>`
 
 License
 =======
@@ -52,7 +52,7 @@ Your domain needs to be set up:
 Installation
 ============
 
-``cd`` to your DocumentRoot_ and download the latest release, then unzip it into the ``html`` directory:
+``cd`` to your :manual:`DocumentRoot <web-documentroot>` and download the latest release, then unzip it into the ``html`` directory:
 
 .. code-block:: console
  :emphasize-lines: 1,2,6
@@ -81,7 +81,7 @@ Choose your desired language.
 Step 2: Database Setup
 ----------------------
 
-Akaunting saves your data in a MySQL database. We suggest you use an `additional database`_. You need to create this database before you enter the database credentials in the installer.
+Akaunting saves your data in a MySQL database. We suggest you use an :manual_anchor:`additional database <database-mysql.html#additional-databases>`. You need to create this database before you enter the database credentials in the installer.
 
 .. code-block:: console
  :emphasize-lines: 1
@@ -121,14 +121,10 @@ You can update the installation in the update wizzard which you can find in the 
 
 
 .. _Akaunting: https://akaunting.com
-.. _MySQL: https://manual.uberspace.de/en/database-mysql.html
-.. _domains: https://manual.uberspace.de/en/web-domains.html
 .. _feed: https://github.com/akaunting/akaunting/releases.atom
 .. _GPLv3: https://www.gnu.org/licenses/gpl-3.0.html
 .. _PHP: http://www.php.net/
-.. _additional database: https://manual.uberspace.de/en/database-mysql.html#additional-databases
 .. _Laravel: https://laravel.com/
-.. _DocumentRoot: https://manual.uberspace.de/en/web-documentroot.html
 
 
 ----


### PR DESCRIPTION
This enables the official [`extlinks`](http://www.sphinx-doc.org/en/master/usage/extensions/extlinks.html) to improve links to the manual (see #262).

With this change referencing the manual is possible using one of the following directives:
```rst
  * :manual:`Python <lang-python>`
  * :manual_anchor:`Change Python version <lang-python.html#change-version>`
```
There are two different directives at the moment to support anchors while avoiding having to write the `.html` part in the "default" case. This may be changed if needed - as well as the naming of the second directive.

An additional change is to unify the indentation of the code inside the configuration file according to the values inside the `.editorconfig` file.