### PR TITLE
Do not use hardcoded lab URL for directive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# replace with 1.7.3 once released
 sphinx>=1.7.3,<2.0.0
 sphinx-rtd-theme==0.4.*
 sphinx-autobuild==0.7.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # replace with 1.7.3 once released
-git+git://github.com/sphinx-doc/sphinx@b5ddc8c6977ac964e3ba4a2eb4647decdc742f4f
-sphinx-rtd-theme==0.2.*
+sphinx>=1.7.3,<2.0.0
+sphinx-rtd-theme==0.4.*
 sphinx-autobuild==0.7.*
 feedgen==0.6.1
 ./authorship

--- a/source/conf.py
+++ b/source/conf.py
@@ -93,11 +93,11 @@ extlinks = {
         ''
     ),
     'lab': (
-        'https://lab.uberspace.de/%s.html',
+        '%s.html',
         ''
     ),
     'lab_anchor': (
-        'https://lab.uberspace.de/%s',
+        '%s',
         ''
     ),
 }

--- a/source/guide_babybuddy.rst
+++ b/source/guide_babybuddy.rst
@@ -53,7 +53,7 @@ You need `pipenv`_, a package manager/virtual environment tool for Python, so in
    Downloading https://files.pythonhosted.org/packages/33/5d/314c760d4204f64e4a968275182b7751bd5c3249094757b39ba987dcfb5a/virtualenv-16.4.3-py2.py3-none-any.whl (2.0MB)
      100% |████████████████████████████████| 2.0MB 614kB/s
   […]
- [isabell@stardust ~]$ 
+ [isabell@stardust ~]$
 
 .. include:: includes/install-uwsgi.rst
 
@@ -155,17 +155,17 @@ Use this snippet to generate a random string to use as secret key:
   :emphasize-lines: 6,8,15,16,17,18,19,20
 
    from .base import *
-   
+
    # Production settings
    # See babybuddy.settings.base for additional settings information.
-   
+
    SECRET_KEY = '<secretkey>'
-   
+
    ALLOWED_HOSTS = ['<host>']
-   
+
    # Database
    # https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-   
+
    DATABASES = {
       'default': {
         'ENGINE': 'django.db.backends.mysql',
@@ -176,9 +176,9 @@ Use this snippet to generate a random string to use as secret key:
         'PORT': '3306',
       }
    }
-   
+
    # Static files
-   
+
    MEDIA_ROOT = os.path.join(BASE_DIR, '../data/media')
 
 To work correctly with the Uberspace Proxy, you need to add this option to the end of the file:
@@ -261,7 +261,7 @@ To deploy your application with uwsgi, create a file at ``~/uwsgi/apps-enabled/b
 .. note:: Find the location of the pipenv virtual environment for the ``virtualenv`` parameter with the following command:
 
  ::
- 
+
   [isabell@stardust ~]$ cd ~/babybuddy/public/ && pipenv --venv
   /home/isabell/.local/share/virtualenvs/public-xxxxxx
 
@@ -271,23 +271,23 @@ To deploy your application with uwsgi, create a file at ``~/uwsgi/apps-enabled/b
   [uwsgi]
   project = babybuddy
   base_dir = $(HOME)/babybuddy
-  
+
   virtualenv = $(HOME)/.local/share/virtualenvs/public-xxxxxx
   chdir = %(base_dir)/public
   module =  %(project).wsgi:application
   env = DJANGO_SETTINGS_MODULE=%(project).settings.production
   master = True
   vacuum = True
-  
+
   http = :<yourport>
-  
+
   wsgi-file = %(base)/public/babybuddy/wsgi.py
   touch-reload = %(wsgi-file)
-  
+
   app = wsgi
-  
+
   plugin = python
-  
+
   uid = $(USER)
   gid = $(USER)
 
@@ -311,3 +311,8 @@ Change all default passwords.
 
 .. _`Baby Buddy`: https://github.com/cdubz/babybuddy
 .. _pipenv: https://github.com/pypa/pipenv
+
+
+----
+
+.. authors::

--- a/source/guide_bludit.rst
+++ b/source/guide_bludit.rst
@@ -17,15 +17,15 @@ Bludit_ is a web application to build your own website or blog in seconds, it's 
 
 .. note:: For this guide you should be familiar with the basic concepts of
 
-  * PHP_
-  * Domains_
+  * :manual:`PHP <lang-php>`
+  * :manual:`Domains <web-domains>`
 
 License
 =======
 
-Bludit_ are released under the MIT License. 
+Bludit_ is released under the MIT License.
 
-All relevant legal information can be found here 
+All relevant legal information can be found here
 
   * https://tldrlegal.com/license/mit-license
   * https://docs.bludit.com/en/#license
@@ -33,7 +33,7 @@ All relevant legal information can be found here
 Prerequisites
 =============
 
-We're using PHP_ in the stable version 7.1:
+We're using :manual:`PHP <lang-php>` in the stable version 7.1:
 
 ::
 
@@ -48,7 +48,7 @@ Your blog domain needs to be setup:
 Installation
 ============
 
-``cd`` to your `document root`_, then download and configure Bludit_.
+``cd`` to your :manual:`document root <web-documentroot>`, then download and configure Bludit_.
 
 .. code-block:: console
  :emphasize-lines: 1,2
@@ -62,31 +62,31 @@ Installation
 
  2019-02-27 20:02:16 (1.58 MB/s) - ‘3.8.0.tar.gz’ saved [1016833]
  [isabell@stardust html]$
- 
-Untar the archive and then delete it. 
+
+Untar the archive and then delete it.
 
 .. code-block:: console
  :emphasize-lines: 1,5
- 
+
  [isabell@stardust html]$ tar -xzvf 3.8.0.tar.gz --strip-components=1
  bludit-3.8.0/.github/
  […]
  bludit-3.8.0/install.php
  [isabell@stardust html]$ rm 3.8.0.tar.gz
- [isabell@stardust html]$ 
+ [isabell@stardust html]$
 
 
 Finishing installation
 ======================
 
-Now point your Browser to your installation URL ``https://isabell.uber.space/install.php``. 
+Now point your Browser to your installation URL ``https://isabell.uber.space/install.php``.
 Complete the form and follow the installation instructions.
 
 You will need to enter the following information:
 
   * language: the language you prefer.
   * admin password: set up your admin password.
-  
+
 
 Tuning
 ======
@@ -99,7 +99,7 @@ Updates
 
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
-Your first plugin you have to install, is the **Version** plugin. It will show you in the admin panel the current used version of bludit. When there will be a new version of bludit, the plugin show you an info and a link to the bludit site. 
+Your first plugin you have to install, is the **Version** plugin. It will show you in the admin panel the current used version of bludit. When there will be a new version of bludit, the plugin show you an info and a link to the bludit site.
 To install log into admin panel and go to **Plugins**. The last plugin at the list ist **Version**. Only click activate and wait a moment. There it is.
 
 Update
@@ -140,13 +140,13 @@ Untar the archive and replace existing files. After this, delete the tar file.
 
 .. code-block:: console
  :emphasize-lines: 1,5
- 
+
  [isabell@stardust html]$ tar -xzvf 3.8.1.tar.gz --strip-components=1
  bludit-3.8.1/.github/
  […]
  bludit-3.8.1/install.php
  [isabell@stardust html]$ rm 3.8.1.tar.gz
- [isabell@stardust html]$ 
+ [isabell@stardust html]$
 
 5. Log into the admin area and check your settings.
 
@@ -158,23 +158,23 @@ Folder structure of Bludit.
 
 /html
     /bl-content/    « Databases and uploaded images
-    
+
     /bl-kernel/     « Core of Bludit
-    
+
     /bl-languages/  « Languages files
-    
+
     /bl-plugins/    « Plugins
-    
+
     /bl-themes/     « Themes
-    
+
 
 /bl-content/
 **************
 
 .. note:: This folder is very important, it is where Bludit stores all files, as well as databases and images. Before making some update it's highly recommended to make a backup of this folder.
 
-.. important:: 
- 
+.. important::
+
  **databases/**
     **plugins/ (Database: plugins)**
         - pages.php       (Database: pages)
@@ -208,7 +208,7 @@ This folder contains the core of Bludit.
 
 This folder contains all language files, each file is a JSON document, encoded in UTF-8.
 
-/bl-languages/    
+/bl-languages/
 ++++++++++++++
     * bg_BG.json
     * cs_CZ.json
@@ -251,11 +251,11 @@ Password recovery for user *admin*
 
 When you forgot the admin password, you can reset it manually.
 
-1. Download the file recovery.php_ from Bludit_ in your `document root`_.
+1. Download the file recovery.php_ from Bludit_ in your :manual:`document root <web-documentroot>`.
 
 .. code-block:: console
  :emphasize-lines: 2
- 
+
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/html/
  [isabell@stardust html]$ wget https://raw.githubusercontent.com/bludit/password-recovery-tool/master/recovery.php
  […]
@@ -274,7 +274,7 @@ When you forgot the admin password, you can reset it manually.
 
 .. code-block:: console
  :emphasize-lines: 2
- 
+
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/html/
  [isabell@stardust html]$ rm recovery.php
  [isabell@stardust html]$
@@ -282,12 +282,8 @@ When you forgot the admin password, you can reset it manually.
 
 
 
-
-.. _PHP: https://manual.uberspace.de/en/lang-php.html
-.. _Domains: https://manual.uberspace.de/en/web-domains.html
 .. _feed: https://github.com/bludit/bludit/releases.atom
 .. _Bludit: https://www.bludit.com
-.. _`document root`: https://manual.uberspace.de/en/web-documentroot.html
 .. _Github: https://github.com/bludit/bludit/releases
 .. _recovery.php: https://raw.githubusercontent.com/bludit/password-recovery-tool/master/recovery.php
 

--- a/source/guide_miniflux.rst
+++ b/source/guide_miniflux.rst
@@ -29,7 +29,7 @@ The software is licensed under `Apache License 2.0`_. All relevant information c
 Prerequisites
 =============
 
-.. warning:: PostgreSQL has to be setup as shown in this :lab_anchor:`Guide <guide_postgresql#database-and-user-management>`! Especially, you'll need to know your PostgreSQL Port ``MyPostgreSQLPort``
+.. warning:: PostgreSQL has to be setup as shown in this :lab_anchor:`Guide <guide_postgresql.html#database-and-user-management>`! Especially, you'll need to know your PostgreSQL Port ``MyPostgreSQLPort``
 
 You’ll need to create a user and a database in PostgreSQL first.
 


### PR DESCRIPTION
This changes the `:lab:` and `:lab_anchor:` directives to create domain-less links instead of the old ones enforcing links to `lab.uberspace.de` as discussed in #331. Additionally a broken link in the Miniflux guide gets fixed and the new guides are ported to use the directives if needed.

Besides this I updated the `requirements.txt` file to use a newer `sphinx-rtd-theme` version and to get rid of the Git commit for `sphinx` as the corresponding version mentioned inside the comment has been published nearly a year ago.