### PR TITLE
[simpleid] Use real random source to generate salt

### DIFF
--- a/source/guide_simpleid.rst
+++ b/source/guide_simpleid.rst
@@ -122,7 +122,7 @@ First we'll generate a random salt to make this secure as possible. You are free
 
 ::
 
- [isabell@stardust ~]$ date +%s | sha256sum | base64 | head -c 16 ; echo
+ [isabell@stardust ~]$ head -c32 /dev/urandom | base64 | head -c 16 ; echo
  MySuperSecretSalt
  [isabell@stardust ~]$
  


### PR DESCRIPTION
Using a time stamp to derive randomness is critical as it allows informed
attackers to bruteforce the random information. While the implications in the
Uberspace setting might be manageable, it is still bad habit and should be
avoided at least for the sake of example.

This commit derives the salt from /dev/urandom, which is a cryptographically
sound source of randomness available on all Linux systems.