### PR TITLE
[mailman3] Remove web backend warning

### DIFF
--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -7,10 +7,6 @@
   .. image:: _static/images/mailman.jpg
       :align: center
       
-.. important:: Due to changes in our network setup this guide is not working. 
-
-  See `issue 344 <https://github.com/Uberspace/lab/issues/344>`_ for discussion and a workaround.
-
 #########
 Mailman 3
 #########


### PR DESCRIPTION
Removes the warning about web backends and possible workaround as the guide has been updated.
Was originally done in #359 but unforunately forgotten in necessary manual merge.