### PR TITLE
[go] add guide for go

### DIFF
--- a/source/_static/images/go.svg
+++ b/source/_static/images/go.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="レイヤー_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" width="401.98px" height="559.472px" viewBox="0 0 401.98 559.472" enable-background="new 0 0 401.98 559.472"
+	 xml:space="preserve">
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#F6D2A2" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M10.634,300.493c0.764,15.751,16.499,8.463,23.626,3.539c6.765-4.675,8.743-0.789,9.337-10.015
+	c0.389-6.064,1.088-12.128,0.744-18.216c-10.23-0.927-21.357,1.509-29.744,7.602C10.277,286.542,2.177,296.561,10.634,300.493"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#C6B198" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M10.634,300.493c2.29-0.852,4.717-1.457,6.271-3.528"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#6AD7E5" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M46.997,112.853C-13.3,95.897,31.536,19.189,79.956,50.74L46.997,112.853z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#6AD7E5" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M314.895,44.984c47.727-33.523,90.856,42.111,35.388,61.141L314.895,44.984z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#F6D2A2" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M325.161,494.343c12.123,7.501,34.282,30.182,16.096,41.18c-17.474,15.999-27.254-17.561-42.591-22.211
+	C305.271,504.342,313.643,496.163,325.161,494.343z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="none" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M341.257,535.522c-2.696-5.361-3.601-11.618-8.102-15.939"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#F6D2A2" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M108.579,519.975c-14.229,2.202-22.238,15.039-34.1,21.558c-11.178,6.665-15.454-2.134-16.461-3.92
+	c-1.752-0.799-1.605,0.744-4.309-1.979c-10.362-16.354,10.797-28.308,21.815-36.432C90.87,496.1,100.487,509.404,108.579,519.975z"
+	/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="none" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M58.019,537.612c0.542-6.233,5.484-10.407,7.838-15.677"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M49.513,91.667c-7.955-4.208-13.791-9.923-8.925-19.124
+	c4.505-8.518,12.874-7.593,20.83-3.385L49.513,91.667z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M337.716,83.667c7.955-4.208,13.791-9.923,8.925-19.124
+	c-4.505-8.518-12.874-7.593-20.83-3.385L337.716,83.667z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#F6D2A2" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M392.475,298.493c-0.764,15.751-16.499,8.463-23.626,3.539c-6.765-4.675-8.743-0.789-9.337-10.015
+	c-0.389-6.064-1.088-12.128-0.744-18.216c10.23-0.927,21.357,1.509,29.744,7.602C392.831,284.542,400.932,294.561,392.475,298.493"
+	/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#C6B198" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M392.475,298.493c-2.29-0.852-4.717-1.457-6.271-3.528"/>
+<g>
+	<path fill-rule="evenodd" clip-rule="evenodd" fill="#6AD7E5" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+		M195.512,13.124c60.365,0,116.953,8.633,146.452,66.629c26.478,65.006,17.062,135.104,21.1,203.806
+		c3.468,58.992,11.157,127.145-16.21,181.812c-28.79,57.514-100.73,71.982-160,69.863c-46.555-1.666-102.794-16.854-129.069-59.389
+		c-30.826-49.9-16.232-124.098-13.993-179.622c2.652-65.771-17.815-131.742,3.792-196.101
+		C69.999,33.359,130.451,18.271,195.512,13.124"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" stroke="#000000" stroke-width="2.9081" stroke-linecap="round" d="
+	M206.169,94.16c10.838,63.003,113.822,46.345,99.03-17.197C291.935,19.983,202.567,35.755,206.169,94.16"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" stroke="#000000" stroke-width="2.8214" stroke-linecap="round" d="
+	M83.103,104.35c14.047,54.85,101.864,40.807,98.554-14.213C177.691,24.242,69.673,36.957,83.103,104.35"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M218.594,169.762c0.046,8.191,1.861,17.387,0.312,26.101c-2.091,3.952-6.193,4.37-9.729,5.967c-4.89-0.767-9.002-3.978-10.963-8.552
+	c-1.255-9.946,0.468-19.576,0.785-29.526L218.594,169.762z"/>
+<g>
+	<ellipse fill-rule="evenodd" clip-rule="evenodd" cx="107.324" cy="95.404" rx="14.829" ry="16.062"/>
+	<ellipse fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" cx="114.069" cy="99.029" rx="3.496" ry="4.082"/>
+</g>
+<g>
+	<ellipse fill-rule="evenodd" clip-rule="evenodd" cx="231.571" cy="91.404" rx="14.582" ry="16.062"/>
+	<ellipse fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" cx="238.204" cy="95.029" rx="3.438" ry="4.082"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" stroke="#000000" stroke-width="3" stroke-linecap="round" d="
+	M176.217,168.87c-6.47,15.68,3.608,47.035,21.163,23.908c-1.255-9.946,0.468-19.576,0.785-29.526L176.217,168.87z"/>
+<g>
+	<path fill-rule="evenodd" clip-rule="evenodd" fill="#F6D2A2" stroke="#231F20" stroke-width="3" stroke-linecap="round" d="
+		M178.431,138.673c-12.059,1.028-21.916,15.366-15.646,26.709c8.303,15.024,26.836-1.329,38.379,0.203
+		c13.285,0.272,24.17,14.047,34.84,2.49c11.867-12.854-5.109-25.373-18.377-30.97L178.431,138.673z"/>
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M176.913,138.045c-0.893-20.891,38.938-23.503,43.642-6.016
+		C225.247,149.475,178.874,153.527,176.913,138.045C175.348,125.682,176.913,138.045,176.913,138.045z"/>
+</g>
+</svg>

--- a/source/guide_go.rst
+++ b/source/guide_go.rst
@@ -42,6 +42,17 @@ Check the download_ page for the newest version.
 ::
 
  [isabell@stardust ~]$ wget -O ~/go.tar.gz https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+ --2019-05-23 13:16:46--  https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+ Resolving dl.google.com (dl.google.com)... 74.125.206.93, 74.125.206.190, 74.125.206.136, ...
+ Connecting to dl.google.com (dl.google.com)|74.125.206.93|:443... connected.
+ HTTP request sent, awaiting response... 200 OK
+ Length: 127938445 (122M) [application/octet-stream]
+ Saving to: ‘/home/isabell/go.tar.gz’
+ 
+ 100%[=====================================================>]  127,938,445  148MB/s   in 0.8s
+ 
+ 2019-05-23 13:16:47 (148 MB/s) - ‘/home/isabell/go.tar.gz’ saved [127938445/127938445]
+ 
  [isabell@stardust ~]$
 
 Extract Go archive
@@ -57,15 +68,15 @@ We extract the go archive to the home directory as it creates a directory called
 Setup environment variables
 ---------------------------
 
-To use go we need to add ~/go/bin to the path environment variable and persist that change for the next shell session (your next login to your uberspace).
+To use go we need to add ``~/go/bin`` to the path environment variable and persist that change for the next shell session (your next login to your uberspace).
 
-Add the following to the end of your ~/.bashrc:
+Add the following to the end of your ``~/.bashrc``:
 
 ::
 
  export PATH=$PATH:$HOME/go/bin
 
-After that reload your .bashrc:
+After that reload your ``.bashrc``:
 
 ::
 
@@ -76,6 +87,13 @@ Finishing installation
 ======================
 
 Now you can test your go installation by running "go version" and building a test program.
+
+::
+
+ [isabell@stardust ~]$ go version
+ go version go1.12.5 linux/amd64
+ [isabell@stardust ~]$
+
 
 Updates
 =======

--- a/source/guide_go.rst
+++ b/source/guide_go.rst
@@ -1,0 +1,92 @@
+.. highlight:: console
+
+.. author:: Raphael Höser <raphael@hoeser.info
+
+.. categorize your guide! refer to the manual for the current list of tags: https://manual.uberspace.de/tags
+.. tag:: lang-go
+
+.. sidebar:: About
+
+  .. image:: _static/images/go.svg
+      :align: center
+
+###
+Go
+###
+
+.. tag_list::
+
+Go_, also known as Golang, is a statically typed, compiled programming language designed at Google by Robert Griesemer, Rob Pike, and Ken Thompson. Go_ is syntactically similar to C, but with memory safety, garbage collection, structural typing, and CSP-style concurrency.
+
+License
+=======
+
+Golang is distrubuted under a BSD style license.
+
+All relevant legal information can be found here
+
+  * https://golang.org/LICENSE
+
+Installation
+============
+
+Download go binary for linux, amd64
+-----------------------------------
+
+In this guide we install go 1.12.5. In the future you might want to change the version to the most current version.
+
+Check the download_ page for the newest version.
+
+::
+
+ [isabell@stardust ~]$ wget -O ~/go.tar.gz https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz
+ [isabell@stardust ~]$
+
+Extract Go archive
+------------------
+
+We extract the go archive to the home directory as it creates a directory called "go" which we'll use as the go root directory.
+
+::
+
+ [isabell@stardust ~]$ tar -xzf go.tar.gz
+ [isabell@stardust ~]$
+
+Setup environment variables
+---------------------------
+
+To use go we need to add ~/go/bin to the path environment variable and persist that change for the next shell session (your next login to your uberspace).
+
+Add the following to the end of your ~/.bashrc:
+
+::
+
+ export PATH=$PATH:$HOME/go/bin
+
+After that reload your .bashrc:
+
+::
+
+ [isabell@stardust ~]$ source ~/.bashrc
+ [isabell@stardust ~]$
+
+Finishing installation
+======================
+
+Now you can test your go installation by running "go version" and building a test program.
+
+Updates
+=======
+
+.. note:: Check the download_ page regularly to stay informed about the newest version.
+
+.. _Go: https://golang.org/
+.. _download: https://golang.org/dl/
+
+To Update go you just need to delete ~/go and redo the installation without editing the .bashrc file (skip the step "Setup environment variables").
+
+----
+
+Tested with Go 1.12.5
+
+.. author_list::

--- a/source/guide_go.rst
+++ b/source/guide_go.rst
@@ -27,6 +27,8 @@ All relevant legal information can be found here
 
   * https://golang.org/LICENSE
 
+.. note:: In most cases it will work totally fine to (cross-) compile your application for GOOS=linux and GOARCH="amd64" on your local device and upload the result to your uberspace as this wouldn't need a go installation on your uberspace (see `cross compiling go`_ for a guide). If that doesn't work for you, feel free to follow this guide.
+
 Installation
 ============
 
@@ -82,6 +84,7 @@ Updates
 
 .. _Go: https://golang.org/
 .. _download: https://golang.org/dl/
+.. _`cross compiling go`: https://golangcookbook.com/chapters/running/cross-compiling/
 
 To Update go you just need to delete ~/go and redo the installation without editing the .bashrc file (skip the step "Setup environment variables").
 


### PR DESCRIPTION
This is a new version of #382 which doesn't use linuxbrew.

This closes #379 

.Merging this should alse help #353 to continue as Buffalo seems to need a running go installation.