### PR TITLE
 configure MySQL instead of sqlite

### DIFF
--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -95,6 +95,28 @@ If you need to add multiple host names, seperate thim with commas like this:
 
  ALLOWED_HOSTS = ['isabell.uber.space', 'www.isabell.example']
 
+MySQL
+-----
+
+To be able to use django 2.2 you need to use MySQL instead of sqlite,
+since the sqlite provided by uberspace is not supported anymore. But since
+you can just use a MySQL provided by uberspace, this isn't so bad ;)
+
+Open ``~/MyDjangoProject/MyDjangoProject/settings.py`` and
+edit the database block to look like this 
+``
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.mysql',
+	      'NAME': 'DB_NAME',
+       	'USER': 'DB_USER',
+        'PASSWORD': 'DB_PASSWORD',
+       	'HOST': 'localhost',
+    }
+}
+
+Your MySQL credentials can be found in the uberspace datasheet.
+
 Configure web server
 --------------------
 

--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -44,6 +44,8 @@ Your URL needs to be setup:
  isabell.uber.space
  [isabell@stardust ~]$
 
+.. include:: includes/my-print-defaults.rst
+
 Installation
 ============
 
@@ -98,9 +100,10 @@ If you need to add multiple host names, seperate thim with commas like this:
 MySQL
 -----
 
-To be able to use django 2.2 you need to use MySQL instead of sqlite,
-since the sqlite provided by uberspace is not supported anymore. But since
-you can just use a MySQL provided by uberspace, this isn't so bad ;)
+It is recommended to run Django with a database other than the default
+SQLite once you go into production. Additionally, the SQLite version
+provided by the underlying CentOS 7 is too old for Django >=2.2. The
+following step changes the database engine to the better performing MySQL.
 
 Open ``~/MyDjangoProject/MyDjangoProject/settings.py`` and
 edit the database block to look like this
@@ -110,15 +113,12 @@ edit the database block to look like this
   DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
-	      'NAME': 'DB_NAME',
+	    'NAME': 'DB_NAME',
        	'USER': 'DB_USER',
         'PASSWORD': 'DB_PASSWORD',
        	'HOST': 'localhost',
     }
   }
-
-
-Your MySQL credentials can be found in the uberspace datasheet.
 
 Configure web server
 --------------------

--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -103,7 +103,7 @@ since the sqlite provided by uberspace is not supported anymore. But since
 you can just use a MySQL provided by uberspace, this isn't so bad ;)
 
 Open ``~/MyDjangoProject/MyDjangoProject/settings.py`` and
-edit the database block to look like this 
+edit the database block to look like this
 ``
 DATABASES = {
     'default': {
@@ -114,6 +114,7 @@ DATABASES = {
        	'HOST': 'localhost',
     }
 }
+``
 
 Your MySQL credentials can be found in the uberspace datasheet.
 

--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -107,7 +107,7 @@ edit the database block to look like this
 
 ::
 
-DATABASES = {
+  DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
 	      'NAME': 'DB_NAME',
@@ -115,7 +115,7 @@ DATABASES = {
         'PASSWORD': 'DB_PASSWORD',
        	'HOST': 'localhost',
     }
-}
+  }
 
 
 Your MySQL credentials can be found in the uberspace datasheet.

--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -104,7 +104,9 @@ you can just use a MySQL provided by uberspace, this isn't so bad ;)
 
 Open ``~/MyDjangoProject/MyDjangoProject/settings.py`` and
 edit the database block to look like this
-``
+
+::
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
@@ -114,7 +116,7 @@ DATABASES = {
        	'HOST': 'localhost',
     }
 }
-``
+
 
 Your MySQL credentials can be found in the uberspace datasheet.
 


### PR DESCRIPTION
I suggest a paragraph on how to configure MySQL, since the uberspace version of sqlite is not supported by django 2.2 anymore.