### PR TITLE
Add 404 page (not found)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ sphinx>=1.7.3,<2.0.0
 sphinx-rtd-theme==0.4.*
 sphinx-autobuild==0.7.*
 feedgen==0.6.1
+sphinx-notfound-page==0.3
 -e ./authorship

--- a/source/404.rst
+++ b/source/404.rst
@@ -1,0 +1,9 @@
+####################
+404 - Page not found
+####################
+
+Sorry, the page you're looking for was not found.
+
+Please select a page from the side menu or feel free to create a issue on github.com_.
+
+.. _github.com: https://github.com/Uberspace/lab/issues

--- a/source/404.rst
+++ b/source/404.rst
@@ -4,6 +4,6 @@
 
 Sorry, the page you're looking for was not found.
 
-Please select a page from the side menu or feel free to create a issue on github.com_.
+Please select a page from the side menu or feel free to create an issue on github.com_.
 
 .. _github.com: https://github.com/Uberspace/lab/issues

--- a/source/conf.py
+++ b/source/conf.py
@@ -35,6 +35,7 @@ import sphinx_rtd_theme
 extensions = [
     'authorship',
     'sphinx.ext.extlinks',
+    'notfound.extension',
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -149,6 +150,9 @@ html_sidebars = {
     ]
 }
 
+# sphinx-notfound-page
+# https://github.com/rtfd/sphinx-notfound-page
+notfound_no_urls_prefix = True
 
 # -- Options for HTMLHelp output ------------------------------------------
 


### PR DESCRIPTION
I added a **404** - page using [sphinx-notfound-page](https://sphinx-notfound-page.readthedocs.io/en/latest/).

The 404.rst file is not rendered in the TOC but will be converted to a 404.html file that is displayed on netlify, if a broken link is clicked :)

Maybe someone knows a neat little gif, that fits onto that page :laughing: 

Issue: #269

**Screenshot**:
![Screenshot from 2019-06-15 20-09-08](https://user-images.githubusercontent.com/4034031/59554807-7b286280-8fa9-11e9-8fb1-02c4f61237a7.png)


