### PR TITLE
Harmonize indentation of code blocks in includes

### DIFF
--- a/source/includes/open-port.rst
+++ b/source/includes/open-port.rst
@@ -1,9 +1,9 @@
 To make the application accessible from the outside, open a `port in the firewall <firewall_>`_:
-  
-  .. code-block:: bash
-   
-   [isabell@stardust ~] uberspace port add
-   Port 40132 will be open for TCP and UDP traffic in a few minutes.
-   [isabell@stardust ~]$
+
+.. code-block:: bash
+
+ [isabell@stardust ~] uberspace port add
+ Port 40132 will be open for TCP and UDP traffic in a few minutes.
+ [isabell@stardust ~]$
 
 .. _firewall: https://manual.uberspace.de/basics-ports.html


### PR DESCRIPTION
This closes #446 

## Before
<img width="232" alt="before" src="https://user-images.githubusercontent.com/441011/61140922-b5175680-a4cc-11e9-8d08-c692000d94af.png">

## After
<img width="234" alt="after" src="https://user-images.githubusercontent.com/441011/61140932-b9dc0a80-a4cc-11e9-853d-a3a5fb8bebf8.png">

