### PR TITLE
Update CodiMD guide for latest 1.5.0 release

### DIFF
--- a/source/guide_codimd.rst
+++ b/source/guide_codimd.rst
@@ -272,6 +272,8 @@ Example:
 
 A backup of the original content can be found in ``config.json.example``.
 
+.. note:: In case you are performing an update, use ``rm config.json && cp ../codimd-old/config.json .``.
+
 .. note::
 
   ``config.json`` is read whenever the server is started via ``node app.js``. In order to make it use the the ``production`` section of ``config.json``, one has to set ``NODE_ENV`` accordingly: ``NODE_ENV=production node app.js``.

--- a/source/guide_codimd.rst
+++ b/source/guide_codimd.rst
@@ -487,7 +487,11 @@ If everything is fine, migrate the database and delete your backup:
 .. code-block:: console
 
   [isabell@stardust codimd]$ node_modules/.bin/sequelize db:migrate
-  [...]
+  
+  Sequelize CLI [Node: 8.13.0, CLI: 5.5.0, ORM: 5.8.12]
+  
+  Parsed url mysql://isabell:*****@localhost:3306/isabell_codimd
+  No migrations were executed, database schema was already up to date.
   [isabell@stardust codimd]$ supervisorctl start codimd
   codimd: started
   [isabell@stardust codimd]$ cd ..

--- a/source/guide_codimd.rst
+++ b/source/guide_codimd.rst
@@ -500,6 +500,6 @@ If everything is fine, migrate the database and delete your backup:
 
 ----
 
-Tested with CodiMD 1.4.0 and Uberspace 7.3.3.0
+Tested with CodiMD 1.5.0 and Uberspace 7.3.4.2
 
 .. author_list::

--- a/source/guide_codimd.rst
+++ b/source/guide_codimd.rst
@@ -448,6 +448,11 @@ Updates
 
 Perform the following steps, to update your `CodiMD`_ installation.
 
+Make a backup of your data
+--------------------------
+
+Backup your notes by opening the main page at ``isabell.example`` and selecting "Export user data" from the top right user menu. In order to also backup notes from other users, have a look at section "Working with dumps" in the :manual:`MySQL <database-mysql>` manual.
+
 Stop the service and backup the old installation directory
 ----------------------------------------------------------
 


### PR DESCRIPTION
[Version 1.5.0](https://github.com/codimd/server/releases/tag/1.5.0) of CodiMD was just released.
I verified that the current guide still works for the new version and improved three minor aspects.