### PR TITLE
remove `curl -I localhost:8000` from guide_django.rst

### DIFF
--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -164,7 +164,7 @@ Perform a CURL request to djangos port to see if your installation succeeded:
 
 ::
 
- [isabell@stardust ~]$ curl -I localhost:8000
+ [isabell@stardust ~]$ curl -I isabell.uber.space
  HTTP/1.1 200 OK
  Content-Type: text/html
  X-Frame-Options: SAMEORIGIN


### PR DESCRIPTION
curl -I localhost:8000 is misleading cause localhost is not part of the ALLOWED_HOSTS and so it spawns 400.