### PR TITLE
Update Neos guide for version 5

### DIFF
--- a/source/guide_neos.rst
+++ b/source/guide_neos.rst
@@ -39,12 +39,13 @@ Neos is free and open source software licensed under `GPL v3`_.
 Prerequisites
 =============
 
-We're using PHP_ in the stable version 7.1:
+Neos (version 5.0 and newer) requires at least PHP_ 7.2. Since new Uberspaces are currently setup with PHP 7.1 by default you need to set this version manually:
 
 ::
 
- [isabell@stardust ~]$ uberspace tools version show php
- Using 'PHP' version: '7.1'
+ [isabell@stardust ~]$ uberspace tools version use php 7.2
+ Selected PHP version 7.2
+ The new configuration is adapted immediately. Patch updates will be applied automatically.
  [isabell@stardust ~]$
 
 .. include:: includes/my-print-defaults.rst
@@ -131,10 +132,9 @@ Updates
 
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
-Check Neos' `releases <https://github.com/neos/neos/releases>`_ for the latest versions. If a newer
-version is available, you should manually update your installation.
+Check Neos' `releases <https://github.com/neos/neos/releases>`_ for the latest versions. If a newer version is available, you should manually update your installation.
 
-By using composer, you can update an existing installation to a specific version, without having to create a new project. But you have to follow version specific update instructions which you can find at the end of the official download_ page on the Neos website.
+By using composer, you can update an existing installation to a specific version, without having to create a new project. But you have to follow version specific upgrade instructions which you can find in the Neos `docs <https://docs.neos.io/cms/references/upgrade-instructions>`_.
 
 .. warning:: Neos, Flow and especially **additional packages** are **not** updated automatically, so make sure to regularly check any update options.
 
@@ -142,11 +142,10 @@ By using composer, you can update an existing installation to a specific version
 .. _Neos: https://www.neos.io/
 .. _PHP: http://www.php.net/
 .. _feed: https://github.com/neos/neos/releases.atom
-.. _download: https://www.neos.io/download-and-extend.html
 .. _GPL v3: https://opensource.org/licenses/GPL-3.0
 
 ----
 
-Tested with Neos 4.1.7 and Uberspace 7.1.15
+Tested with Neos 5.0.0 and Uberspace 7.3.6
 
 .. author_list::


### PR DESCRIPTION
Closes #484

Changed: 
* mention PHP 7.2 as base requirement and tell users to set this version manually
* update outdated link to upgrade instructions
* bump "tested with"