### PR TITLE
Change author attribution in my guides

### DIFF
--- a/source/guide_akaunting.rst
+++ b/source/guide_akaunting.rst
@@ -1,6 +1,6 @@
 .. highlight:: console
 
-.. author:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <https://danielkratz.com>
 
 .. tag:: lang-php
 .. tag:: web

--- a/source/guide_bookstack.rst
+++ b/source/guide_bookstack.rst
@@ -1,6 +1,6 @@
 .. highlight:: console
 
-.. author:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <https://danielkratz.com>
 
 .. tag:: lang-php
 .. tag:: web

--- a/source/guide_grav.rst
+++ b/source/guide_grav.rst
@@ -1,6 +1,6 @@
 .. highlight:: console
 
-.. author:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <https://danielkratz.com>
 
 .. tag:: lang-php
 .. tag:: web

--- a/source/guide_kirby.rst
+++ b/source/guide_kirby.rst
@@ -1,4 +1,4 @@
-.. author:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <https://danielkratz.com>
 
 .. tag:: lang-php
 .. tag:: web

--- a/source/guide_neos.rst
+++ b/source/guide_neos.rst
@@ -1,6 +1,6 @@
 .. highlight:: console
 
-.. author:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <https://danielkratz.com>
 
 .. tag:: lang-php
 .. tag:: web

--- a/source/guide_octobercms.rst
+++ b/source/guide_octobercms.rst
@@ -1,6 +1,6 @@
 .. highlight:: console
 
-.. author:: Daniel Kratz <uberlab@danielkratz.com>
+.. author:: Daniel Kratz <https://danielkratz.com>
 
 .. tag:: lang-php
 .. tag:: web


### PR DESCRIPTION
I'd like to change the author attribution in my guides from a mail adress to my URL (in order to avoid emails regarding the guides). Thanks!