### PR TITLE
[resilio-sync] Add step to open a firewall port for Resilio Sync

### DIFF
--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -61,7 +61,7 @@ Configure web server
 Configure firewall port
 =======================
 
-Resilio Sync will work without this step, however, all connections will be routet through a relay server, since direct connections are blocked by the firewall.
+Resilio Sync will work without this step, however, all connections will be routed through a relay server, since direct connections are blocked by the firewall.
 
 .. include:: includes/open-port.rst
 

--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -25,6 +25,7 @@ Resilio_ (formerly BitTorrent Sync) is a proprietary file syncing service simila
 
   * :manual:`supervisord <daemons-supervisord>`
   * :manual:`domains <web-domains>`
+  * :manual:`ports <basics-ports>`
 
 License
 =======
@@ -57,6 +58,34 @@ Configure web server
 
 .. include:: includes/web-backend.rst
 
+Configure firewall port
+=======================
+
+Resilio Sync will work without this step, however, all connections will be routet through a relay server, since direct connections are blocked by the firewall.
+
+.. include:: includes/open-port.rst
+
+Configure Resilio Sync
+======================
+
+Create a config file ``~/.sync/resilio-sync.conf`` with the follwoing contents:
+
+.. warning:: Replace ``<username>`` with your username and ``<port>`` with the apropiate port number, which was opened in the previous step (would be 40132 in our example).
+
+.. code-block:: text 
+
+ {
+   "device_name": "Uberspace",
+   "listening_port" : <port>, // 0 - randomize port
+
+    "storage_path" : "/home/<username>/.sync",
+
+    "webui" :
+  	{
+    	"listen" : "0.0.0.0:9000" // remove field to disable WebUI
+	}
+ }
+
 Configure ``supervisord``
 =========================
 
@@ -65,7 +94,7 @@ Create ``~/etc/services.d/resilio-sync.ini`` with the following content:
 .. code-block:: ini
 
  [program:resilio-sync]
- command=rslsync --webui.listen 0.0.0.0:9000 --nodaemon --storage /home/isabell/.sync
+ command=rslsync --nodaemon --config /home/isabell/.sync/resilio-sync.conf
 
 Start Service
 =============


### PR DESCRIPTION
Opening a custom port allows Resilio Sync to establish direct connections to peers,
instead of relying on a relay server.

Setting the "listening_port" has to be done through a configuration
file. For consistency, all command line arguments  are included in this file.