### PR TITLE
Fix typos in guides found by sphinxcontrib.spelling

### DIFF
--- a/source/guide_akaunting.rst
+++ b/source/guide_akaunting.rst
@@ -97,7 +97,7 @@ Akaunting saves your data in a MySQL database. We suggest you use an :manual_anc
  [isabell@stardust ~]$ mysql -e "CREATE  DATABASE ${USER}_akaunting"
  [isabell@stardust ~]$
 
-Enter the following informations into the installer:
+Enter the following information into the installer:
 
   * your MySQL hostname, username and password: the hostname is ``localhost`` and you should know your MySQL :manual_anchor:`credentials <database-mysql.html#login-credentials>` by now. If you don't, start reading again at the top.
   * the name of your newly created Akaunting database (e.g. ``isabell_akaunting``)
@@ -105,7 +105,7 @@ Enter the following informations into the installer:
 Step 3: Company and Admin Details
 ---------------------------------
 
-Fill in the name of your company, the company email adress (email sender if you send e.g. invoices), an admin email adress and your admin password.
+Fill in the name of your company, the company email address (email sender if you send e.g. invoices), an admin email address and your admin password.
 
 **That's it.** After the installation you can login with your chosen admin credentials.
 
@@ -123,9 +123,9 @@ Updates
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
 You will be additionally notified about available updates in the built in notification center.
-You can update the installation in the update wizzard which you can find in the Akaunting web interface.
+You can update the installation in the update wizard which you can find in the Akaunting web interface.
 
-.. warning:: Please note that third-party apps (plugins) need to be updated seperately. Available app updates are listed directly under the core updates. Make sure to check these regularly.
+.. warning:: Please note that third-party apps (plugins) need to be updated separately. Available app updates are listed directly under the core updates. Make sure to check these regularly.
 
 
 .. _Akaunting: https://akaunting.com

--- a/source/guide_babybuddy.rst
+++ b/source/guide_babybuddy.rst
@@ -229,7 +229,7 @@ In our example, the file ``~/babybuddy/public/babybuddy/settings/production.py``
 Step 6
 ------
 
-Enter the virtual environment, initialize the database tables and exit the virtual environemt again:
+Enter the virtual environment, initialize the database tables and exit the virtual environment again:
 
 ::
 

--- a/source/guide_bludit.rst
+++ b/source/guide_bludit.rst
@@ -107,7 +107,7 @@ Updates
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
 Your first plugin you have to install, is the **Version** plugin. It will show you in the admin panel the current used version of bludit. When there will be a new version of bludit, the plugin show you an info and a link to the bludit site.
-To install log into admin panel and go to **Plugins**. The last plugin at the list ist **Version**. Only click activate and wait a moment. There it is.
+To install log into admin panel and go to **Plugins**. The last plugin at the list is **Version**. Only click activate and wait a moment. There it is.
 
 Update
 ------

--- a/source/guide_bookstack.rst
+++ b/source/guide_bookstack.rst
@@ -65,7 +65,7 @@ To install BookStack clone the release branch of the official repository one lev
  […]
  [isabell@stardust ~]$
 
-``cd`` into your BookStack directory and install the neccessary dependencies using Composer_.
+``cd`` into your BookStack directory and install the necessary dependencies using Composer_.
 
 .. code-block:: console
 

--- a/source/guide_commento.rst
+++ b/source/guide_commento.rst
@@ -129,7 +129,7 @@ Now you should be able to access Commento at your defined domain in your browser
 Additional Notes
 ----------------
 
-If you are the only user of the Commento instance, it would be adviseable to disable the new owner sign up, after you registered your site.
+If you are the only user of the Commento instance, it would be advisable to disable the new owner sign up, after you registered your site.
 Add this to your ``commento_daemon`` above the ``/home/isabell/commento/commento`` call:
 
 .. note:: This doe not impact the commenting users of your site!
@@ -147,7 +147,7 @@ Then restart Commento:
  commento: started
  [isabell@stardust ~]$
 
-The form to sign up will still be visisble, but cannot be submitted.
+The form to sign up will still be visible, but cannot be submitted.
 
 .. _Commento: https://commento.io
 

--- a/source/guide_cryptpad.rst
+++ b/source/guide_cryptpad.rst
@@ -145,7 +145,7 @@ Now let's start the service:
 Customization
 =============
 
-For any futher configuration or customization you should have a look at the `Cryptpad Wiki`_.
+For any further configuration or customization you should have a look at the `Cryptpad Wiki`_.
 
 Updates
 =======
@@ -165,7 +165,7 @@ If there is a new version available, you can get the code using git. Replace the
 
   [isabell@stardust cryptpad]$
 
-Now updated dependecies:
+Now updated dependencies:
 
 .. code-block:: console
 

--- a/source/guide_django.rst
+++ b/source/guide_django.rst
@@ -62,7 +62,7 @@ Install django
 
 .. hint::
 
-  Depening on your database configuration, additional modules like ``mysqlclient`` might be required.
+  Depending on your database configuration, additional modules like ``mysqlclient`` might be required.
 
 Create a django project. We will use "MyDjangoProject" during this guide.
 

--- a/source/guide_dokuwiki.rst
+++ b/source/guide_dokuwiki.rst
@@ -78,7 +78,7 @@ You will need to enter the following information:
   * ACL: It´s recommended that ACL is enable.
   * Superuser: The login name of the admin user.
   * Real Name: Your name, nickname or something else (don´t use superuser name!)
-  * E-Mail: The e-mail adresse of the admin user.
+  * E-Mail: The e-mail address of the admin user.
   * Password: The superduper secure password of the admin user.
   * Initial ACL policy: Choose the type of your wiki.
   * Allow users to register themselves: your decision

--- a/source/guide_drupal.rst
+++ b/source/guide_drupal.rst
@@ -210,7 +210,7 @@ Insert this configuration for the domains given above:
 Cronjob
 -------
 
-For executing periodical tasks like e.g. updatíng the search index, purging old logs or checking for updates,
+For executing periodical tasks like e.g. updating the search index, purging old logs or checking for updates,
 you will need to create a cronjob.
 
 Get your cron url for your site at ``Administration > Configuration > System > Cron (/admin/config/system/cron)``.

--- a/source/guide_eqdkp-plus.rst
+++ b/source/guide_eqdkp-plus.rst
@@ -16,7 +16,7 @@ EQdkp Plus
 
 .. tag_list::
 
-EQdkp-Plus_ is an open source Content Management System (CMS) and Guild Management System in PHP and distributed unter the AGPLv3 licence.
+EQdkp-Plus_ is an open source Content Management System (CMS) and Guild Management System in PHP and distributed under the AGPLv3 licence.
 It is focused on supporting guilds and clans playing online games, especially MMORPGs. Therefore it brings tools for planning raids or distributing loot or points like DKP (Dragon Kill Points).
 
 ----
@@ -60,7 +60,7 @@ Installation
  [isabell@stardust html]$ unzip eqdkp-plus.zip && rm eqdkp-plus.zip
  [isabell@stardust html]$
 
-Now point your browser to your uberspace URL and follow the instructions of the Installer Assistent.
+Now point your browser to your uberspace URL and follow the instructions of the Installer Assistant.
 
 You will need to enter the following information:
   * your MySQL hostname, username and password: the hostname is ``localhost`` and you should know your MySQL :manual_anchor:`credentials <database-mysql.html#login-credentials>` by now. If you don't, start reading again at the top.

--- a/source/guide_etherpad.rst
+++ b/source/guide_etherpad.rst
@@ -174,7 +174,7 @@ Personalization
 
 Take a deeper look into the ``~/etherpad/settings.json``, you still might want to adjust the title or the welcoming text of new created pads. If you want to use plugins, you will also need to set up a admin account there.
 
-You can also personalize the look of your installation by including custom css- oder js-files. See `Custom static files`_ in the documentation for further information.
+You can also personalize the look of your installation by including custom css- or js-files. See `Custom static files`_ in the documentation for further information.
 
 **Important**: You need to place your custom-files in ``~/etherpad/node_modules/ep_etherpad-lite/static/custom`` **not** ``~/etherpad/static/custom`` for being recognized by your installation.
 

--- a/source/guide_ezmlm.rst
+++ b/source/guide_ezmlm.rst
@@ -149,7 +149,7 @@ To remove the list simply delete the directory ``~/lists/mylist`` and the ``.qma
 Subscribing / Unsubscribing
 ---------------------------
 
-Users can either subscribe thenselves to a list by writing an email to ``mylist-subscribe@isabell.uber.space`` or can be added from the command line:
+Users can either subscribe themselves to a list by writing an email to ``mylist-subscribe@isabell.uber.space`` or can be added from the command line:
 
 ::
 

--- a/source/guide_flatboard.rst
+++ b/source/guide_flatboard.rst
@@ -17,7 +17,7 @@ Flatboard
 
 .. tag_list::
 
-Flatboard_ is a simple, lightweight, modern and fast flat-file forum, using Json and Markdown [1]_ or BBcode.
+Flatboard_ is a simple, lightweight, modern and fast flat-file forum, using JSON and Markdown [1]_ or BBcode.
 
 ----
 
@@ -95,9 +95,9 @@ Then push the Unzip-Button.
 
   * titel: titel of your forum
   * description: what is your forum about
-  * E-Mail: your admin e-mail adress
+  * E-Mail: your admin e-mail address
   * administrator: set up your admin password
-  * language: the language you prefer (English, French, German, Russian, Italiano) « Yes, the question is double.
+  * language: the language you prefer (English, French, German, Russian, Italian) « Yes, the question is double.
 
 At least you have to delete the ``install.php``.
 

--- a/source/guide_freshrss.rst
+++ b/source/guide_freshrss.rst
@@ -92,7 +92,7 @@ Now remove your ``html`` directory and create a symbolic link ``html -> FreshRSS
 Configuration
 =============
 
-Point your browser to your domain, e.g. ``https://isabell.uber.space`` and follow the instructions to set up FreshRSS. In step 3, we recommend to use a seperate database such as ``<username>_freshrss``. Replace ``<username>`` with your actual user name.
+Point your browser to your domain, e.g. ``https://isabell.uber.space`` and follow the instructions to set up FreshRSS. In step 3, we recommend to use a separate database such as ``<username>_freshrss``. Replace ``<username>`` with your actual user name.
 
 Cron job
 --------

--- a/source/guide_ghost.rst
+++ b/source/guide_ghost.rst
@@ -198,7 +198,7 @@ You now need to readjust your ``~/ghost/config.production.json`` to change the U
      "host": "0.0.0.0"
    },
 
-Kill and restart Ghost (also check the restartet process with second command):
+Kill and restart Ghost (also check the restarted process with second command):
 
 .. code-block:: console
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -48,7 +48,7 @@ Your gitea URL needs to be setup:
 Installation
 ============
 
-Like a lot of Go software, gitea is distributed as a single binary. Download Gitea's latests `release <https://github.com/go-gitea/gitea/releases/latest>`_,
+Like a lot of Go software, gitea is distributed as a single binary. Download Gitea's latest `release <https://github.com/go-gitea/gitea/releases/latest>`_,
 verify the checksum specified in the respective ``.sha256`` file and finally
 make sure that the file can be executed.
 

--- a/source/guide_goaccess.rst
+++ b/source/guide_goaccess.rst
@@ -70,7 +70,7 @@ Launch
 Step 1 - First Try (or Realtime Analysis in the Shell)
 ------------------------------------------------------
 
-To get first results, to check that everthing is maintained, please enter:
+To get first results, to check that everything is maintained, please enter:
 
 ::
 

--- a/source/guide_gotify.rst
+++ b/source/guide_gotify.rst
@@ -54,7 +54,7 @@ Note the `--remove-prefix` option here. Without it, gotify will not work behind 
 Installation
 ============
 
-Like a lot of Go software, gotify is distributed as a single binary. Download gotify's latests `release <https://github.com/gotify/server/releases/latest>`_, unzip it and make sure that the file can be executed.
+Like a lot of Go software, gotify is distributed as a single binary. Download gotify's latest `release <https://github.com/gotify/server/releases/latest>`_, unzip it and make sure that the file can be executed.
 
 ::
 

--- a/source/guide_grafana.rst
+++ b/source/guide_grafana.rst
@@ -73,7 +73,7 @@ Installation
 Step 1
 ------
 
-Find the latest version of grafana_ for the plattform ``linux`` from the `download page <https://grafana.com/grafana/download?platform=linux>`_, download and extract it and enter the extracted directory:
+Find the latest version of grafana_ for the platform ``linux`` from the `download page <https://grafana.com/grafana/download?platform=linux>`_, download and extract it and enter the extracted directory:
 
 ::
 

--- a/source/guide_gsales2.rst
+++ b/source/guide_gsales2.rst
@@ -20,7 +20,7 @@ GSALES 2
 .. tag_list::
 
 GSALES 2 is a very flexible german billing application specialized for generating recurring invoices.
-Equipped with a well documentated SOAP API you can easily attach tools and third party apps to GSALES 2 to fit your needs.
+Equipped with a well documented SOAP API you can easily attach tools and third party apps to GSALES 2 to fit your needs.
 
 
 

--- a/source/guide_hugo.rst
+++ b/source/guide_hugo.rst
@@ -165,7 +165,7 @@ Updates
 
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
-If there is a new version available, update the ``hugo`` binary in ``~/bin`` (repeat Step 2). It might be a good idea to rebuild your site, too, but that's not strictly neccessary.
+If there is a new version available, update the ``hugo`` binary in ``~/bin`` (repeat Step 2). It might be a good idea to rebuild your site, too, but that's not strictly necessary.
 
 
 .. _Git: https://git-scm.com/book/en/v2/Getting-Started-Installing-Git/

--- a/source/guide_jekyll.rst
+++ b/source/guide_jekyll.rst
@@ -123,7 +123,7 @@ Now open a browser and navigate to your URL where you can see your beautiful res
 
 Best practices
 ======================
-If you dont want to create and modify your website on your uberspace, you can install Ruby, Jekyll and git on your local machine and then push it to your uberspace where it gets deployed automatically. This is an easy way to work with an editor of your choice and you can test your website befor publishing it.
+If you don't want to create and modify your website on your uberspace, you can install Ruby, Jekyll and git on your local machine and then push it to your uberspace where it gets deployed automatically. This is an easy way to work with an editor of your choice and you can test your website before publishing it.
 
 To install Ruby, Windows users should use RubyInstaller_, Linux and Mac users could use RVM_.
 

--- a/source/guide_jingo.rst
+++ b/source/guide_jingo.rst
@@ -91,7 +91,7 @@ You then have to configure the Git repository with name and email, if you haven'
   [isabell@stardust jingo_data]$ git config user.email "$USER@uber.space"
   [isabell@stardust jingo_data]$
 
-.. note:: You can of course set arbitrary informations here. If you want to share your data using Github for example, you might want to set the appropriate data.
+.. note:: You can of course set arbitrary information here. If you want to share your data using Github for example, you might want to set the appropriate data.
 
 Change the configuration
 ------------------------

--- a/source/guide_joomla.rst
+++ b/source/guide_joomla.rst
@@ -48,7 +48,7 @@ Installation
 
 ``cd`` to your :manual:`document root <web-documentroot>`, then download the latest release of *Joomla!* and extract it:
 
-.. note:: The link to the lastest version can be found at Joomla!'s `download page <https://downloads.joomla.org/>`_.
+.. note:: The link to the latest version can be found at Joomla!'s `download page <https://downloads.joomla.org/>`_.
 
 ::
 
@@ -78,8 +78,8 @@ Page 2 - Database Configuration:
 Page 3 - Finalization
   * Install Sample Data: up to you...
   * Email Configuration: up to you...
-  * Check that all Pre-Installation Checks are fullfilled (a green ``Yes``)
-  * Check that all Recommended Settings are fullfilled (for me the only difference was ``Output Buffering`` which is recommended to *off*, but is *on* in my case -- it does not matter, Joomla! will still operate)
+  * Check that all Pre-Installation Checks are fulfilled (a green ``Yes``)
+  * Check that all Recommended Settings are fulfilled (for me the only difference was ``Output Buffering`` which is recommended to *off*, but is *on* in my case -- it does not matter, Joomla! will still operate)
 
 Hit ``Install``!
 You should see a message ``Congratulations! Joomla! is now installed``

--- a/source/guide_kimai.rst
+++ b/source/guide_kimai.rst
@@ -70,7 +70,7 @@ Check the current `stable release`_ and copy the version number which you have t
  […]
  [isabell@stardust ~]$
 
-Install all neccessary dependencies using Composer. This can take some time.
+Install all necessary dependencies using Composer. This can take some time.
 
 ::
 
@@ -117,7 +117,7 @@ Save the changed file and start the installation using the Kimai console.
 Finishing installation
 ======================
 
-Finish the installation by creating an admin user with the Kimai console. Insert your username and email adress in the shell command. You will be prompted to insert a password afterwards.
+Finish the installation by creating an admin user with the Kimai console. Insert your username and email address in the shell command. You will be prompted to insert a password afterwards.
 
 Please don't use ``admin`` as your username and set yourself a strong password.
 

--- a/source/guide_kirby.rst
+++ b/source/guide_kirby.rst
@@ -76,7 +76,7 @@ Configuration
 
 Visit your domain followed by ``/panel`` (e.g. ``isabell.uber.space/panel``) to visit the admin panel and create your admin account. Please use a strong password for this.
 
-When you're ready to launch your website with Kirby you need to purchase a license_. To register your license login to the admin panel, click register in the upper right corner and enter the neccessary information.
+When you're ready to launch your website with Kirby you need to purchase a license_. To register your license login to the admin panel, click register in the upper right corner and enter the necessary information.
 
 Please make sure to deactivate the debug mode for your site when going live. Edit the ``site/config/config.php`` file and set the ``debug`` option to ``false`` to achieve that.
 

--- a/source/guide_mailman.rst
+++ b/source/guide_mailman.rst
@@ -130,7 +130,7 @@ In case errors are found, you should definitely fix them before continuing.
 Step 4
 ------
 
-If you want the webinterface to be available publically, we need to create a couple of SymLinks and an htaccess-file:
+If you want the webinterface to be public available, we need to create a couple of SymLinks and an htaccess-file:
 
 ::
 

--- a/source/guide_mattermost.rst
+++ b/source/guide_mattermost.rst
@@ -92,7 +92,7 @@ First, set your site URL:
 
     "SiteURL": "https://isabell.uber.space"
 
-Then find the ``SqlSettings`` block and replace ``mmuser`` with your username, ``mostest`` with your MySQL password and ``mattermost_test`` with the name of the databse you created earlier:
+Then find the ``SqlSettings`` block and replace ``mmuser`` with your username, ``mostest`` with your MySQL password and ``mattermost_test`` with the name of the database you created earlier:
 
 .. code-block:: javascript
  :emphasize-lines: 3

--- a/source/guide_memcached.rst
+++ b/source/guide_memcached.rst
@@ -105,7 +105,7 @@ Try running ``memcached`` to make sure everything works:
 
 If no errors occur, then everything should be fine and you can exit the program with ``Ctrl`` + ``C``.
 
-Copy the ``memcached`` binari to your `~/bin` folder:
+Copy the ``memcached`` binary to your `~/bin` folder:
 
 .. code-block:: console
 
@@ -134,7 +134,7 @@ If it’s not in state RUNNING, check your configuration.
 Testing memcached
 -----------------
 
-Test if memcached is responing on it's assigned port by issuing the following command to display the current configuration parameters.
+Test if memcached is responding on it's assigned port by issuing the following command to display the current configuration parameters.
 
 .. code-block:: console
 

--- a/source/guide_minim.rst
+++ b/source/guide_minim.rst
@@ -19,7 +19,7 @@ minim
 
 minim_ offers a super simple PHP Content Management System. The code is Open Source and you're free to modify, distribute and use it for private and commercial projects.
 
-It'is ideal for simple travel blogs or publishing news. It has an easy administration interface and an automatic generated RSS feed. Themes and other modifications are fully customisable.
+It is ideal for simple travel blogs or publishing news. It has an easy administration interface and an automatic generated RSS feed. Themes and other modifications are fully customisable.
 
 ----
 

--- a/source/guide_minio.rst
+++ b/source/guide_minio.rst
@@ -17,7 +17,7 @@ MinIO
 .. tag_list::
 
 MinIO_ is an open source object storage server,
-compatible with Amazon S3 writen in go.
+compatible with Amazon S3 written in go.
 
 ----
 
@@ -140,7 +140,7 @@ Just stop MinIO and replace the old binary with the newer one:
 
 MinIO docs
 ==========
-Offical MinIO Docs: https://docs.min.io
+Official MinIO Docs: https://docs.min.io
 
 .. _Minio: https://min.io
 .. _client: https://docs.min.io/docs/minio-client-quickstart-guide.html

--- a/source/guide_neos.rst
+++ b/source/guide_neos.rst
@@ -61,7 +61,7 @@ Since Neos uses the subdirectory Web/ as web root you should not install Neos in
 
 ``cd`` to one level above your :manual:`DocumentRoot <web-documentroot>`, then use the dependency manager Composer to create a new project based on the Neos base distribution:
 
-.. note:: Composer will install all neccessary dependencies Neos needs to run. This can take some time.
+.. note:: Composer will install all necessary dependencies Neos needs to run. This can take some time.
 
 ::
 

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -56,7 +56,7 @@ Installation
 
 ``cd`` to your :manual:`document root <web-documentroot>`, then download the latest release of the Nextcloud and extract it:
 
-.. note:: The link to the lastest version can be found at Nextcloud's `download page <https://nextcloud.com/install/#instructions-server>`_.
+.. note:: The link to the latest version can be found at Nextcloud's `download page <https://nextcloud.com/install/#instructions-server>`_.
 
 ::
 
@@ -93,7 +93,7 @@ Add the following cronjob to your :manual:`crontab <daemons-cron>`:
 Memcaching
 ----------
 
-To further enhance perfomance, enable Memcaching.
+To further enhance performance, enable Memcaching.
 
 To enable Memcaching (APCu), add the following line to your /var/www/virtual/$USER/html/config/config.php:
 

--- a/source/guide_octobercms.rst
+++ b/source/guide_octobercms.rst
@@ -63,7 +63,7 @@ We will install October using the official command-line interface (CLI). To do t
  OctoberCMS successfully installed to: /var/www/virtual/$USER/html
  [isabell@stardust ~]$
 
-The installer script will download all necessary files including the CLI so you can directly continue with the configuation of your October installation afterwards.
+The installer script will download all necessary files including the CLI so you can directly continue with the configuration of your October installation afterwards.
 
 Configuration
 =============
@@ -93,7 +93,7 @@ The following list contains information on what you need to enter in the CLI set
     #. Database name: ``isabell_october`` (the name of the database you just created)
     #. MySQL login: ``isabell`` (your username)
     #. MySQL password: your MySQL password that you've got from ``my_print_defaults client``
-    #. First name, Last name, Email adress: your account information
+    #. First name, Last name, Email address: your account information
     #. Admin login: your admin username (to follow security best practices please don't use ``admin`` here)
     #. Admin password: your admin password (please choose a strong, secure password to prevent hacking of your installation)
     #. Confirm that the entered information is correct
@@ -107,7 +107,7 @@ You can now visit your domain and you will see the frontend of the installed dem
 Best practices
 ==============
 
-You can use the October CLI which we used to setup your instace also to e.g. install plugins. See the `Console command list`_ to explore all possibilities.
+You can use the October CLI which we used to setup your instance also to e.g. install plugins. See the `Console command list`_ to explore all possibilities.
 
 Updates
 =======

--- a/source/guide_postgresql.rst
+++ b/source/guide_postgresql.rst
@@ -189,7 +189,7 @@ After the installation of PostgreSQL, it is necessary to configure the network e
 Configure the Unix Socket
 -------------------------
 
-The Unix socket will be configured to the standard port. You must set the environment varables with your new port:
+The Unix socket will be configured to the standard port. You must set the environment variables with your new port:
 
 Edit your ``~/.bashrc`` and add the following content:
 

--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -69,9 +69,9 @@ Resilio Sync will work without this step, however, all connections will be route
 Configure Resilio Sync
 ======================
 
-Create a config file ``~/.sync/resilio-sync.conf`` with the follwoing contents:
+Create a config file ``~/.sync/resilio-sync.conf`` with the following contents:
 
-.. warning:: Replace ``<username>`` with your username and ``<port>`` with the apropiate port number, which was opened in the previous step (would be 40132 in our example).
+.. warning:: Replace ``<username>`` with your username and ``<port>`` with the appropriate port number, which was opened in the previous step (would be 40132 in our example).
 
 .. code-block:: text
 

--- a/source/guide_rocketchat.rst
+++ b/source/guide_rocketchat.rst
@@ -269,7 +269,7 @@ Create ``~/etc/services.d/rocket.chat.ini`` with the following content:
  autostart=yes
  autorestart=yes
 
-.. note:: Don't forget to replace all occurences of ``<password>`` and to set your ``ROOT_URL`` if you don't use your default uberspace domain!
+.. note:: Don't forget to replace all occurrences of ``<password>`` and to set your ``ROOT_URL`` if you don't use your default uberspace domain!
 
 Now let's start the service:
 

--- a/source/guide_roundcube.rst
+++ b/source/guide_roundcube.rst
@@ -228,7 +228,7 @@ Get the latest version
 
 ``cd`` to your :manual:`home directory <basics-home>` (e.g. ``/home/isabell``), download the latest release of Roundcube and extract it.
 
-.. warning:: Make sure to download and extract the tarball to a different location as your active roundcube installation to prevent an accidetalliy override!
+.. warning:: Make sure to download and extract the tarball to a different location as your active roundcube installation to prevent an accidental override!
 
 .. note:: Check the Roundcube_ website or `Github Repository`_ for the latest stable release and copy the download link to the Complete.tar.gz file. Then use ``wget`` to download it. Replace the URL with the one you just got from GitHub/Website.
 
@@ -247,7 +247,7 @@ Update your existing Roundcube installation
 
 ``cd`` to the downloaded and extracted roundcube directory and execute the ``installto.sh``-Script bundled with Roundcube to easily update your installation. The script first copies all updated files to the target directory and then runs the update script that will update/migrate your local configuration files and update the database schema if necessary.
 
-.. note:: Make sure to change the directory folloewd by the script-call to your active roundcube directory ``bin/installto.sh **<your-existing-roundcube-directory>**``. The Output of the Updatescript can vary depening of your your version and which files have been changed.
+.. note:: Make sure to change the directory followed by the script-call to your active roundcube directory ``bin/installto.sh **<your-existing-roundcube-directory>**``. The Output of the Updatescript can vary depending of your your version and which files have been changed.
 
 .. code-block:: console
  :emphasize-lines: 1,2,3

--- a/source/guide_sharex.rst
+++ b/source/guide_sharex.rst
@@ -55,7 +55,7 @@ Firstly we need to add a domain(in this case a subdomain).
 Step 2
 ------
 
-Now we need to create the coresponding directory for our subdomain.
+Now we need to create the corresponding directory for our subdomain.
 
 ::
 
@@ -80,7 +80,7 @@ Now click "**Add**" to create a new destination for our pictures.
 
 Step 3
 ------
-Now write the following in the coresponding fields.
+Now write the following in the corresponding fields.
 
 ::
 
@@ -102,7 +102,7 @@ To setup your Workflow do the following:
 
 
  1. Navigate to ":menuselection:`Destinations --> Image Uploader`" and check **FTP**.
- 2. Navigate to "**After Capture tasks**" and be sure to activate "**Open in image editor**", "**Save image to file**" and finaly "**Upload image to host**".
+ 2. Navigate to "**After Capture tasks**" and be sure to activate "**Open in image editor**", "**Save image to file**" and finally "**Upload image to host**".
  3. Navigate to "**After upload tasks**" and be sure to activate "**Copy URL to clipboard**".
 
 

--- a/source/guide_simpleid.rst
+++ b/source/guide_simpleid.rst
@@ -52,7 +52,7 @@ Step 1 - Download & Extract
 
 ``cd`` to your :manual:`document root <web-documentroot>`, respectively the folder above, because not all files must/should be accessable via web, then download the latest release of *SimpleID* and extract it:
 
-.. note:: The link to the lastest version can be found at SimpleID's `download page <http://simpleid.koinic.net/releases/>`_.
+.. note:: The link to the latest version can be found at SimpleID's `download page <http://simpleid.koinic.net/releases/>`_.
 
 ::
 

--- a/source/guide_syncthing.rst
+++ b/source/guide_syncthing.rst
@@ -134,7 +134,7 @@ To protect the access to your syncthing instance, visit your domain and set a us
 Best practice
 =============
 
-right now the server will sync with your devices only via a relay-server, wich is not super fast. To improve performance, you can connect directly by opening a port in the firewall
+Right now the server will sync with your devices only via a relay-server, which is not super fast. To improve performance, you can connect directly by opening a port in the firewall
 
 ::
 

--- a/source/guide_taskd.rst
+++ b/source/guide_taskd.rst
@@ -24,8 +24,8 @@ Taskwarrior is Free and Open Source Software that manages your TODO list from th
 
 * Multiple clients
 * TLS secured
-* Andorid App available (also in FDroid)
-* Is MIT-licensed free software.
+* Android-App available (also in FDroid)
+* MIT-licensed free software.
 
 .. _Taskd: https://taskwarrior.org/
 
@@ -135,7 +135,7 @@ Initialization of taskd
 Create Server PKI Certificates and key
 --------------------------------------
 
-The taskd bundles scripts for generating reuqired keys and certificates for everything in the pki directory. We can set all required information in the vars file. But first we follow the recommended step andy copy the pki directory to the ``$TASKDDATA`` directory so we have everything in one place.
+The taskd bundles scripts for generating required keys and certificates for everything in the pki directory. We can set all required information in the vars file. But first we follow the recommended step and copy the pki directory to the ``$TASKDDATA`` directory so we have everything in one place.
 ::
 
  [isabell@stardust ~]$ cp -r /home/isabell/taskd-1.1.0/pki $TASKDDATA
@@ -164,7 +164,7 @@ In our case ``isabell.uber.space`` will not work and lead to a certificate error
  [isabell@stardust ~]$
 
 
-Note that the ``client.*`` files are not used for the clients connecting to the server! We will generate coresponding files in the next section. The client files here are for the API.
+Note that the ``client.*`` files are not used for the clients connecting to the server! We will generate corresponding files in the next section. The client files here are for the API.
 But first we move the required files to the ``$TASKDDATA`` directory:
 ::
 
@@ -236,7 +236,7 @@ Now add as many users as you like. Spaces are ok as long you quote the name.
  Created user 'First Last' for organization 'Public'
  [isabell@stardust ~]$
 
-Remember the user key! This identifies the user (as the name is not neccessary unique).
+Remember the user key! This identifies the user (as the name is not necessary unique).
 Let's put this information in a file just to make things easier especially on Android where you can then copy paste the information. Create a file ``~/Isabell_task_info`` and put this in:
 
 ::
@@ -295,7 +295,7 @@ On your linux machine configure taskwarrior
 
 
 Android:
-Edit the configuration on Android in settings in the menu and add some lines (of course adopt the respective fields like the port of your server and the user-id). Also it may be neccessary to escapt slashes.
+Edit the configuration on Android in settings in the menu and add some lines (of course adopt the respective fields like the port of your server and the user-id). Also it may be necessary to escape slashes.
 
 ::
 

--- a/source/guide_teamspeak.rst
+++ b/source/guide_teamspeak.rst
@@ -22,7 +22,7 @@ TeamSpeak_ is a proprietary voice-over-Internet Protocol (VoIP) application for 
 
 The target audience for TeamSpeak is gamers, who can use the software to communicate with other players on the same team of a multiplayer video game. Communicating by voice gives a competitive advantage by enabling players to keep their hands on the controls.
 
-Teamspeak is an alternativ to Mumble_ and needs a license to run. This can be optained from the the Teamspeak-License_ website and from the ``LICENSE`` file which is part of the downloadable teamspeak file.
+Teamspeak is an alternative to Mumble_ and needs a license to run. This can be obtained from the the Teamspeak-License_ website and from the ``LICENSE`` file which is part of the downloadable teamspeak file.
 
 ----
 
@@ -45,7 +45,7 @@ Prerequisites
 
 .. include:: includes/open-port.rst
 
-Run the commmand four times to retrieve four ports. One open port for the ``default_voice_port``, ``filetransfer_port``, ``query_port`` and ``query_ssh_port``.
+Run the command four times to retrieve four ports. One open port for the ``default_voice_port``, ``filetransfer_port``, ``query_port`` and ``query_ssh_port``.
 
 
 Installation
@@ -171,7 +171,7 @@ Now edit the ``ts3server.ini`` and change the following entries. Use the four po
 Step 4: Test server start
 -------------------------
 
-You can test your configuration by executing the minimal runscript. Use the paramater ``inifile`` with the argument ´´ts3server.ini`` to start the server with your configuration.
+You can test your configuration by executing the minimal runscript. Use the parameter ``inifile`` with the argument ´´ts3server.ini`` to start the server with your configuration.
 
 .. code-block:: console
 

--- a/source/guide_wallabag.rst
+++ b/source/guide_wallabag.rst
@@ -77,7 +77,7 @@ Change to that folder and run ``make install``. During the installation process,
 * ``Would you like to create a new admin user (recommended)?:`` yes
 * ``Username:`` admin *- or you can also choose any other name, that could increase security*
 * ``Password:`` *choose a good password here*
-* ``Email:`` set in a mailadress to use with this admin account
+* ``Email:`` set in a mailaddress to use with this admin account
 
 .. code-block:: console
  :emphasize-lines: 1,2,10,11,12,17,23,25,26,28,30,31,32,33

--- a/source/guide_wiki-js.rst
+++ b/source/guide_wiki-js.rst
@@ -71,7 +71,7 @@ which resolves to the latest archive file, which also comes in handy later for :
   Saving to: ‘wiki-js.tar.gz’
   [isabell@stardust ~]$
 
-Extract the dowloaded archive to the ``wiki`` directory you created earlier.
+Extract the downloaded archive to the ``wiki`` directory you created earlier.
 
 ::
 

--- a/source/guide_wordpress-bedrock.rst
+++ b/source/guide_wordpress-bedrock.rst
@@ -154,7 +154,7 @@ Your site is now ready to use.
 Installing Plugins
 =============================
 
-Unlinke with a "normal" Wordpress-Installation, with bedrock, you cannot install Plugins or edit Code via the Wordpress-Backend. This is intended behaviour and part of the reason to use bedrock in the first place.
+Unlike a "normal" Wordpress-Installation, with bedrock, you cannot install Plugins or edit Code via the Wordpress-Backend. This is intended behaviour and part of the reason to use bedrock in the first place.
 
 Instead you can use composer to manage Plugins. Every Plugin (or Theme) listed in on Wordpress.org is present as a Composer-Package in the  `WPackagist-Repository`_.
 

--- a/source/guide_xbrowsersync.rst
+++ b/source/guide_xbrowsersync.rst
@@ -98,7 +98,7 @@ Afterwards leave the shell with the ``exit`` command.
 Installation
 ------------
 
-Now you can install all the depenencies needed for xBrowserSync by using npm.
+Now you can install all the dependencies needed for xBrowserSync by using npm.
 Additionally you can let npm run a so called `security audit`_, which detects and updates insecure dependencies.
 
 ::

--- a/source/guide_yourls.rst
+++ b/source/guide_yourls.rst
@@ -85,9 +85,9 @@ Edit the following parts of your configuration file:
  * change the values of ``YOURLS_DB_USER``, ``YOURLS_DB_PASS``, ``YOURLS_DB_NAME`` to reflect your MySQL :manual_anchor:`credentials <database-mysql.html#login-credentials>`
  * change the value of ``YOURLS_SITE`` to your previously set up domain including the protocol (in this case ``https://isabell.uber.space``)
  * replace the value of ``YOURLS_COOKIEKEY`` with a long random string which is used to secure cookies. You can generate a string using this webservice_ and copy it from there.
- * setup an admin account by editing the username and passwort in the ``yourls_user_passwords`` variable. Don't worry, YOURLS will hash these plain text passwords on the next login attempt. Please don't use ``admin`` as your username and set yourself a strong password.
+ * setup an admin account by editing the username and password in the ``yourls_user_passwords`` variable. Don't worry, YOURLS will hash these plain text passwords on the next login attempt. Please don't use ``admin`` as your username and set yourself a strong password.
 
-Save the configuration file and point your browser to your website URL and append /admin (e.g. ``isabell.uber.space/admin``) to visit the YOURLS admin interface. On your first visit there is only one button called ``Install YOURLS``. CLick this button and the application will finish the setup.
+Save the configuration file and point your browser to your website URL and append /admin (e.g. ``isabell.uber.space/admin``) to visit the YOURLS admin interface. On your first visit there is only one button called ``Install YOURLS``. Click this button and the application will finish the setup.
 
 That's it. You can now login using your account.
 
@@ -97,9 +97,9 @@ Best practices
 Privacy
 --------
 
-By default YOURLS logs every visit on a shortlink with the complete IP adress of the visitor. You might want to change that in regard to the GDPR.
+By default YOURLS logs every visit on a shortlink with the complete IP address of the visitor. You might want to change that in regard to the GDPR.
 
-In order to only save shortened IP adresses for your statistics you can install the plugin yourls-pseudonymize_. To install the plugin clone the plugin repository to ``/user/plugins`` using Git.
+In order to only save shortened IP addresses for your statistics you can install the plugin yourls-pseudonymize_. To install the plugin clone the plugin repository to ``/user/plugins`` using Git.
 
 .. code-block:: console
 

--- a/source/guide_znc.rst
+++ b/source/guide_znc.rst
@@ -39,7 +39,7 @@ Installation
 
 Step 1
 ------
-Create a new directory, download the lastest version and enter the directory you just created:
+Create a new directory, download the latest version and enter the directory you just created:
 
 ::
 


### PR DESCRIPTION
Just out of curiosity I added a spellchecking-feature to the lab build. This found more than 1000 errors, which were mostly because of too specific terms not in the default dictionary. I fixed some of the obvious spelling mistakes in this PR.

The spellcheck integration is in this commit:
https://github.com/ebroda/lab/commit/03e8790eeb80bfb0df68f9f61012c2208cc2e1ee

Run with make spelling to create a report.