### PR TITLE
Clarify --remove-prefix

### DIFF
--- a/source/guide_etherpad.rst
+++ b/source/guide_etherpad.rst
@@ -145,7 +145,7 @@ Configure web server
 
 .. note::
 
-    etherpad-lite is running on port 9001. Additionally, the ``--remove-prefix`` parameter is needed.
+    etherpad-lite is running on port 9001. Additionally, the ``--remove-prefix`` parameter is needed if you want to run Etherpad Lite under a sub URI like ``/pad`` instead of the root URI ``/``.
 
 .. include:: includes/web-backend.rst
 


### PR DESCRIPTION
https://lab.uberspace.de/guide_etherpad.html says in a box:

> etherpad-lite is running on port 9001. Additionally, the --remove-prefix parameter is needed.

In the following example, the `--remove-prefix` parameter is, however, not used. As far as I understand, it is only needed if one wants to run Etherpad Lite under a sub URL like `/ep`.