### PR TITLE
[goaccess] update location of the default configuration

### DIFF
--- a/source/guide_goaccess.rst
+++ b/source/guide_goaccess.rst
@@ -45,7 +45,7 @@ Copy the default configuration:
 
 ::
 
- [isabell@stardust ~]$ cp /etc/goaccess.conf ~/etc/goaccess.conf
+ [isabell@stardust ~]$ cp /etc/goaccess/goaccess.conf ~/etc/goaccess.conf
 
 Edit the configuration file and uncomment the following parameters:
 


### PR DESCRIPTION
The default configuration seems to have been moved to `etc/goaccess/...`.