### PR TITLE
Remove build warnings

### DIFF
--- a/source/guide_ghost.rst
+++ b/source/guide_ghost.rst
@@ -57,7 +57,7 @@ Installation
 ============
 
 Install ghost-cli, knex-migrator and yarn
------------------------------------
+-----------------------------------------
 
 Use ``npm`` to install ``ghost-cli`` and ``knex-migrator`` globally.
 In order to avoid issues and bugs with Ghost_, we need to also install the package manager ``yarn`` to use for further updates.
@@ -235,7 +235,7 @@ Check Ghost's `releases <https://github.com/TryGhost/Ghost/releases/latest>`_ fo
  [isabell@stardust versions]$
 
 Install the required ``node`` modules with ``yarn``
--------------------------------------
+---------------------------------------------------
 
 .. code-block:: console
  :emphasize-lines: 1

--- a/source/guide_matomo.rst
+++ b/source/guide_matomo.rst
@@ -79,7 +79,7 @@ enter crontab with
 
 and enter: (more configuration-details about :manual:`cron <daemons-cron>`)
 
-.. code-block:: guess
+.. code-block::
 
   5 * * * * /usr/bin/php /home/isabell/html/matomo/console core:archive --url=https://isabell.uber.space/ > /dev/null
 


### PR DESCRIPTION
Sphinx throws currently four warnings during the build. This fixes the warnings