### PR TITLE
Update cryptpad to 3.16.0

### DIFF
--- a/source/guide_cryptpad.rst
+++ b/source/guide_cryptpad.rst
@@ -29,21 +29,14 @@ Cryptpad
   * :manual:`supervisord <daemons-supervisord>`
   * :manual:`domains <web-domains>`
 
+
 Prerequisites
 =============
 
-Set up the backends:
+Your webseite domain or subdomain needs to be setup up:
 
-::
+.. include:: includes/web-domain-list.rst
 
-  [isabell@stardust ~]$ uberspace web backend set / --http --port 3000
-  Set backend for / to port 3000; please make sure something is listening!
-  You can always check the status of your backend using "uberspace web backend list".
-  [isabell@stardust ~]$
-
-You need to use ``/`` or ``domain.example/`` in the domain part since subfolders are not allowed in cryptpad.
-
-Now let's get started with Cryptpad.
 
 We're using :manual:`Node.js <lang-nodejs>` in the stable version 10:
 
@@ -63,19 +56,19 @@ We also need `Bower`:
 Installation
 ============
 
-Start with cloning the Cryptpad source code from Github_ and be sure to replace the branch ``2.21.0`` with the current release number from the feed_:
+Start with cloning the Cryptpad source code from Github_ and be sure to replace the branch ``3.16.0`` with the current release number from the feed_:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ git clone --branch 2.21.0 https://github.com/xwiki-labs/cryptpad.git ~/cryptpad
+  [isabell@stardust ~]$ git clone --branch 3.16.0 --depth 1 https://github.com/xwiki-labs/cryptpad.git ~/cryptpad
   Cloning into '~/cryptpad'...
-  remote: Enumerating objects: 172, done.
-  remote: Counting objects: 100% (172/172), done.
-  remote: Compressing objects: 100% (105/105), done.
-  remote: Total 43165 (delta 99), reused 109 (delta 67), pack-reused 42993
-  Receiving objects: 100% (43165/43165), 85.51 MiB | 4.81 MiB/s, done.
-  Resolving deltas: 100% (30989/30989), done.
-  Note: checking out '135182ea0a3500d27afe0146c94e112e1726ae7e'.
+  remote: Enumerating objects: 15111, done.
+  remote: Counting objects: 100% (15111/15111), done.
+  remote: Compressing objects: 100% (11685/11685), done.
+  remote: Total 15111 (delta 3527), reused 14548 (delta 3359), pack-reused 0
+  Receiving objects: 100% (15111/15111), 84.83 MiB | 16.52 MiB/s, done.
+  Resolving deltas: 100% (3527/3527), done.
+  Note: checking out 'b0b4029556d89d8b6b0c30e9dfab528edb65813b'.
 
   You are in 'detached HEAD' state. You can look around, make experimental
   changes and commit them, and you can discard any commits you make in this
@@ -84,27 +77,24 @@ Start with cloning the Cryptpad source code from Github_ and be sure to replace 
   If you want to create a new branch to retain commits you create, you may
   do so (now or later) by using -b with the checkout command again. Example:
 
-    git checkout -b <new-branch-name>
+  git checkout -b <new-branch-name>
 
-  Checking out files: 100% (4319/4319), done.
+  Checking out files: 100% (19152/19152), done.
   [isabell@stardust ~]$
 
 
-Now we need to install some dependencies:
+Now we need to install the dependencies:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ cd ~/cryptpad
   [isabell@stardust cryptpad]$ npm install
+  added 212 packages from 231 contributors and audited 375 packages in 4.828s
   (...)
-  added 168 packages from 186 contributors and audited 311 packages in 14.352s
   found 0 vulnerabilities
   [isabell@stardust cryptpad]$ bower install
   (...)
-  bower install       open-sans-fontface#1.4.2
-  bower install       jquery#2.1.4
-  bower install       bootstrap#4.3.1
-  (...)
+  [isabell@stardust cryptpad]$ 
 
 Configuration
 =============
@@ -116,14 +106,13 @@ Copy example configuration
 
   [isabell@stardust cryptpad]$ cp config/config.example.js config/config.js
 
-Edit ``config/config.js`` and change the value of the variable ``_domain`` to your domain, like so:
+Edit ``config/config.js``, enable and change the value of the variable ``httpSafeOrigin:`` to your domain, like below. Additionally change the ``httpAddress`` that the web backends can listen to them.
 
 .. code-block:: js
 
-  /*
-      globals module
-  */
-  var _domain = 'https://isabell.uber.space/';
+  httpSafeOrigin: "https://isabell.uber.space",
+  (...)
+  httpAddress: '0.0.0.0',
 
 Setup daemon
 ------------
@@ -142,6 +131,15 @@ Now let's start the service:
 
 .. include:: includes/supervisord.rst
 
+	
+Configure web server
+--------------------
+
+.. note::
+
+    Cryptpad is running on port 3000. You need to use ``/`` or a sub-domain since subfolders are not allowed in cryptpad.
+
+.. include:: includes/web-backend.rst
 
 Customization
 =============
@@ -154,28 +152,28 @@ Updates
 .. note:: Check the update feed_ regularly to stay informed about the newest version.
 
 
-If there is a new version available, you can get the code using git. Replace the version number ``2.19.0`` with the latest version number you got from the release feed_:
+If there is a new version available, you can get the code using git. Replace the version number ``3.16.0`` with the latest version number you got from the release feed_:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ cd ~/cryptpad
-  [isabell@stardust cryptpad]$ git pull origin 2.19.0
+  [isabell@stardust cryptpad]$ git pull origin 3.16.0
   From https://github.com/xwiki-labs/cryptpad
-   * tag                 2.19.0     -> FETCH_HEAD
+   * tag                 3.16.0     -> FETCH_HEAD
   Already up to date.
 
   [isabell@stardust cryptpad]$
 
-Now updated dependencies:
+Now update the dependencies:
 
 .. code-block:: console
 
-  [isabell@stardust cryptpad]$ npm i
+  [isabell@stardust cryptpad]$ npm install
   removed 1 package and audited 313 packages in 14.535s
   found 0 vulnerabilities
 
   [isabell@stardust cryptpad]$ bower update
-  {... bower output ...}
+  (...)
   [isabell@stardust cryptpad]$
 
 Then you need to restart the service, so the new code is used by the webserver:
@@ -194,6 +192,6 @@ Then you need to restart the service, so the new code is used by the webserver:
 
 ----
 
-Tested with Cryptpad 2.19.0 and Uberspace 7.2.4.0
+Tested with Cryptpad 3.16.0 and Uberspace 7.6.0
 
 .. author_list::

--- a/source/guide_cryptpad.rst
+++ b/source/guide_cryptpad.rst
@@ -38,12 +38,12 @@ Your webseite domain or subdomain needs to be setup up:
 .. include:: includes/web-domain-list.rst
 
 
-We're using :manual:`Node.js <lang-nodejs>` in the stable version 10:
+We're using :manual:`Node.js <lang-nodejs>` in the stable version 12:
 
 ::
 
- [isabell@stardust ~]$ uberspace tools version use node 10
- Selected Node.js version 10
+ [isabell@stardust ~]$ uberspace tools version use node 12
+ Selected Node.js version 12
  [isabell@stardust ~]$
 
 We also need `Bower`:


### PR DESCRIPTION
I just tried to install Cryptpad. As the guide was quite old, some things have changed, mostly regarding the configuration. 
Also I updated the order in the guide, reduced the git pull a little bit and updated the version.