### PR TITLE
Make crontab entrys generic using $USER

### DIFF
--- a/source/guide_kanboard.rst
+++ b/source/guide_kanboard.rst
@@ -139,7 +139,7 @@ To work properly, Kanboard requires that a `background job`_ runs on a daily bas
 
 ::
 
-  0 8 * * * cd /var/www/virtual/isabell/html && ./cli cronjob >/dev/null 2>&1
+  0 8 * * * cd /var/www/virtual/$USER/html && ./cli cronjob >/dev/null 2>&1
 
 Best practices
 ==============

--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -380,7 +380,12 @@ If you want to use an :manual:`IMAP mailbox<mail-mailboxes>` on your uberspace, 
 Install cronjobs
 ----------------
 
-`Mailman 3`_ offers a :manual_anchor:`cronjobs <daemons-cron.html#cron>` to perform some maintenance actions at regular intervals. To install them for your user, run ``crontab -e`` and add the line ``@daily /home/isabell/.local/bin/mailman digests --send`` at the end of the file.
+`Mailman 3`_ offers a :manual_anchor:`cronjobs <daemons-cron.html#cron>` to perform some maintenance actions at regular intervals. To install them for your user, run ``crontab -e`` and add the following line at the end of the file.
+
+.. code-block:: bash
+
+ @daily /home/$USER/.local/bin/mailman digests --send
+
 
 Using Mailman
 =============

--- a/source/guide_matomo.rst
+++ b/source/guide_matomo.rst
@@ -77,11 +77,11 @@ enter crontab with
 
   [isabell@stardust ~]$ crontab -e
 
-and enter: (more configuration-details about :manual:`cron <daemons-cron>`)
+and enter with your url (more configuration-details about :manual:`cron <daemons-cron>`):
 
 .. code-block:: guess
 
-  5 * * * * /usr/bin/php /home/isabell/html/matomo/console core:archive --url=https://isabell.uber.space/ > /dev/null
+  5 * * * * /usr/bin/php /home/$USER/html/matomo/console core:archive --url=https://isabell.uber.space/ > /dev/null
 
 
 Tracking

--- a/source/guide_passbolt.rst
+++ b/source/guide_passbolt.rst
@@ -135,7 +135,7 @@ line to your crontab using the ``crontab -e`` command:
 
 ::
 
- * * * * * ~/html/bin/cake EmailQueue.sender >> ~/logs/passbolt_mails.log
+ * * * * * /home/$USER/html/bin/cake EmailQueue.sender >> ~/logs/passbolt_mails.log
 
 Updates
 =======


### PR DESCRIPTION
Some crontab entries used isabell as username. This could be more generic to avoid errors of users by using $USER