### PR TITLE
Add shell command for disabling maintenance mode after update

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -206,6 +206,7 @@ In most cases this happens due to wrong `SELinux labels`_ which can be fixed wit
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/html
  [isabell@stardust html]$ php occ upgrade
  [isabell@stardust html]$ restorecon -R .
+ [isabell@stardust html]$ php occ maintenance:mode --off
  [isabell@stardust html]$
 
 .. note:: Check the `changelog <https://nextcloud.com/changelog/>`_ regularly to stay informed about new updates and releases.


### PR DESCRIPTION
Sometimes an update leaves you stuck in maintenance mode.

I've added a line to the shell commands of the update section which disables maintenance mode. It should be safe to always call this, even if maintenance mode is already disabled.