### PR TITLE
Use clang to build redis

### DIFF
--- a/source/guide_redis.rst
+++ b/source/guide_redis.rst
@@ -70,7 +70,7 @@ Build Redis
 .. code-block:: bash
 
  [isabell@stardust ~]$ cd redis-stable/
- [isabell@stardust redis-stable]$ make
+ [isabell@stardust redis-stable]$ CC=clang make
  make[1]: Entering directory `/home/isabell/redis-stable/src'
      CC Makefile.dep
  make[1]: Leaving directory `/home/isabell/redis-stable/src'


### PR DESCRIPTION
Seems like Redis >= 6.0.0 fail to build with the GCC version available on uberspace. Using clang works.

See https://github.com/antirez/redis/issues/6286

Note: This is up for discussion. I just tried to installing redis using this guide and it failed. Using clang worked. But maybe there is a better solution?