### PR TITLE
Update alertmanager, prometheus and grafana versions

### DIFF
--- a/source/guide_alertmanager.rst
+++ b/source/guide_alertmanager.rst
@@ -62,10 +62,10 @@ Find the latest version of alertmanager_ for the operating system ``linux`` and 
 
 ::
 
- [isabell@stardust ~]$ wget https://github.com/prometheus/alertmanager/releases/download/v0.19.0/alertmanager-0.19.0.linux-amd64.tar.gz
- [isabell@stardust ~]$ tar xvzf alertmanager-0.19.0.linux-amd64.tar.gz
- [isabell@stardust ~]$ cd alertmanager-0.19.0.linux-amd64
- [isabell@stardust alertmanager-0.19.0.linux-amd64]$
+ [isabell@stardust ~]$ wget https://github.com/prometheus/alertmanager/releases/download/v0.20.0/alertmanager-0.20.0.linux-amd64.tar.gz
+ [isabell@stardust ~]$ tar xvzf alertmanager-0.20.0.linux-amd64.tar.gz
+ [isabell@stardust ~]$ cd alertmanager-0.20.0.linux-amd64
+ [isabell@stardust alertmanager-0.20.0.linux-amd64]$
 
 Step 2
 ------
@@ -74,9 +74,9 @@ Move the binary to ``~/bin`` and the configuration file to ``~/etc/alertmanager`
 
 ::
 
- [isabell@stardust alertmanager-0.19.0.linux-amd64]$ mv alertmanager ~/bin/
- [isabell@stardust alertmanager-0.19.0.linux-amd64]$ mv alertmanager.yml ~/etc/alertmanager
- [isabell@stardust alertmanager-0.19.0.linux-amd64]$
+ [isabell@stardust alertmanager-0.20.0.linux-amd64]$ mv alertmanager ~/bin/
+ [isabell@stardust alertmanager-0.20.0.linux-amd64]$ mv alertmanager.yml ~/etc/alertmanager
+ [isabell@stardust alertmanager-0.20.0.linux-amd64]$
 
 Configuration
 =============
@@ -139,6 +139,6 @@ Now you can access the web interface via ``http://localhost:8080`` on your works
 
 ----
 
-Tested with alertmanager_ 0.19.0, Uberspace 7.3.6.1
+Tested with alertmanager_ 0.20.0, Uberspace 7.6.1.2
 
 .. author_list::

--- a/source/guide_grafana.rst
+++ b/source/guide_grafana.rst
@@ -77,10 +77,10 @@ Find the latest version of grafana_ for the platform ``linux`` from the `downloa
 
 ::
 
- [isabell@stardust ~]$ wget https://dl.grafana.com/oss/release/grafana-6.3.5.linux-amd64.tar.gz
- [isabell@stardust ~]$ tar xvzf grafana-6.3.5.amd64.tar.gz
- [isabell@stardust ~]$ cd grafana-6.3.5.linux-amd64
- [isabell@stardust grafana-6.3.5.linux-amd64]$
+ [isabell@stardust ~]$ wget https://dl.grafana.com/oss/release/grafana-6.7.3.linux-amd64.tar.gz
+ [isabell@stardust ~]$ tar xvzf grafana-6.7.3.linux-amd64.tar.gz
+ [isabell@stardust ~]$ cd grafana-6.7.3
+ [isabell@stardust grafana-6.7.3]$
 
 Step 2
 ------
@@ -89,9 +89,9 @@ Move the binary to ``~/bin`` and the default configuration and html files to ``~
 
 ::
 
- [isabell@stardust grafana-6.3.5.linux-amd64]$ mv bin/grafana-server ~/bin/
- [isabell@stardust grafana-6.3.5.linux-amd64]$ mv conf public ~/usr/share/grafana
- [isabell@stardust grafana-6.3.5.linux-amd64]$
+ [isabell@stardust grafana-6.7.3]$ mv bin/grafana-server ~/bin/
+ [isabell@stardust grafana-6.7.3]$ mv conf public ~/usr/share/grafana
+ [isabell@stardust grafana-6.7.3]$
 
 Configuration
 =============
@@ -173,6 +173,6 @@ Change the default password which we configured in the configuration file ``~/et
 
 ----
 
-Tested with grafana_ 6.3.5, Uberspace 7.3.6.1
+Tested with grafana_ 6.7.3, Uberspace 7.6.1.2
 
 .. author_list::

--- a/source/guide_prometheus.rst
+++ b/source/guide_prometheus.rst
@@ -64,10 +64,10 @@ Find the latest version of prometheus_ for the operating system ``linux`` and th
 
 ::
 
- [isabell@stardust ~]$ wget https://github.com/prometheus/prometheus/releases/download/v2.12.0/prometheus-2.12.0.linux-amd64.tar.gz
- [isabell@stardust ~]$ tar xvzf prometheus-2.12.0.linux-amd64.tar.gz
- [isabell@stardust ~]$ cd prometheus-2.12.0.linux-amd64
- [isabell@stardust prometheus-2.12.0.linux-amd64]$
+ [isabell@stardust ~]$ wget https://github.com/prometheus/prometheus/releases/download/v2.18.1/prometheus-2.18.1.linux-amd64.tar.gz
+ [isabell@stardust ~]$ tar xvzf prometheus-2.18.1.linux-amd64.tar.gz
+ [isabell@stardust ~]$ cd prometheus-2.18.1.linux-amd64
+ [isabell@stardust prometheus-2.18.1.linux-amd64]$
 
 Step 2
 ------
@@ -76,9 +76,9 @@ Move the binary to ``~/bin`` and the configuration file to ``~/etc/prometheus``.
 
 ::
 
- [isabell@stardust prometheus-2.12.0.linux-amd64]$ mv prometheus ~/bin/
- [isabell@stardust prometheus-2.12.0.linux-amd64]$ mv prometheus.yml ~/etc/prometheus
- [isabell@stardust prometheus-2.12.0.linux-amd64]$
+ [isabell@stardust prometheus-2.18.1.linux-amd64]$ mv prometheus ~/bin/
+ [isabell@stardust prometheus-2.18.1.linux-amd64]$ mv prometheus.yml ~/etc/prometheus
+ [isabell@stardust prometheus-2.18.1.linux-amd64]$
 
 Configuration
 =============
@@ -173,6 +173,6 @@ If this is something you do not want to do, you could hide it behind a basic aut
 
 ----
 
-Tested with Prometheus_ 2.12.0, Uberspace 7.3.6.1
+Tested with Prometheus_ 2.18.1, Uberspace 7.6.1.2
 
 .. author_list::


### PR DESCRIPTION
Hi,

I updated the versions of alertmanager, prometheus and grafana.

grafana: `6.3.5` -> `6.7.3`
prometheus: `2.12.0` -> `2.18.1`
alertmanager: `0.19.0` -> `0.20.0`
"tested w/ uberspace": `7.3.6.1` -> `7.6.1.2`

Best,
Malte