### PR TITLE
[selfoss] Update selfoss guide to use cliupdate.php for updates

### DIFF
--- a/source/guide_selfoss.rst
+++ b/source/guide_selfoss.rst
@@ -152,11 +152,11 @@ Check out the official `selfoss documentation`_ for explanation of further confi
 Cron job
 ========
 
-It is recommended to set up a cron job to automatically update your feeds. Edit your cron tab using the ``crontab -e`` command and insert this cron job to update every 15 minutes. Make sure to replace ``isabell.uber.space`` with your own domain.
+It is recommended to set up a cron job to automatically update your feeds. Edit your cron tab using the ``crontab -e`` command and insert this cron job to update every 15 minutes. Make sure to replace ``/home/isabell/html/cliupdate.php`` with the path to the ``cliupdate.php`` script inside the selfoss folder.
 
 ::
 
- */15 * * * * curl -so /dev/null https://isabell.uber.space/update
+ */15 * * * * php /home/isabell/html/cliupdate.php
 
 .. _selfoss: https://selfoss.aditu.de/
 .. _latest release: https://github.com/SSilence/selfoss/releases/latest

--- a/source/guide_selfoss.rst
+++ b/source/guide_selfoss.rst
@@ -156,7 +156,7 @@ It is recommended to set up a cron job to automatically update your feeds. Edit 
 
 ::
 
- */15 * * * * php /home/isabell/html/cliupdate.php
+ */15 * * * * php /home/isabell/html/cliupdate.php > /dev/null 2>&1
 
 .. _selfoss: https://selfoss.aditu.de/
 .. _latest release: https://github.com/SSilence/selfoss/releases/latest


### PR DESCRIPTION
When I tried the selfoss guide, I ran into the issue that the `/update` endpoint cannot be curl'ed with the default config (error: "unallowed access"). There are two ways to remedy this situation:

1. set the `allow_public_update_access` to `1` (default is unset) and continue to GET the `/update` endpoint, or
2. use the php interpreter to directly call the `cliupdate.php` script

I went for option 2 as it keeps the selfoss instance fully password protected and no authorized endpoints can be called. I have been using this setup successfully for a couple of days. The use of the `cliupdate.php` script is documented in the [offical installation instrucitons](https://selfoss.aditu.de/#installation).