### PR TITLE
Update guide for Radicale 3.0

### DIFF
--- a/source/guide_radicale.rst
+++ b/source/guide_radicale.rst
@@ -126,7 +126,7 @@ Create a file ``~/etc/services.d/radicale.ini`` and put the following in it:
 .. code-block:: ini
 
   [program:radicale]
-  command=radicale -f
+  command=radicale
 
 
 Finishing installation
@@ -200,8 +200,8 @@ Updates
   [isabell@stardust ~]$
 
 .. _Radicale: https://radicale.org/
-.. _Changelog: https://radicale.org/news/
-.. _Config: https://radicale.org/configuration/
+.. _Changelog: https://github.com/Kozea/Radicale/releases/
+.. _Config: https://radicale.org/3.0.html#documentation
 
 ----
 


### PR DESCRIPTION
Just tried to follow the guide to install `radicale>=3` and got the following error in `~/tmp/radicale-stderr---supervisor_[...].log`: 
```
usage: radicale [OPTIONS]
radicale: error: unrecognized arguments: -f
```

Also updated the links to changelog & documentation.