### PR TITLE
[synapse] remove TLS certificate section

### DIFF
--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -179,16 +179,6 @@ This has to be made available under ``/.well-known/matrix`` via the web backend:
   Set backend for /.well-known/matrix to apache.
   [isabell@stardust ~]$
 
-Configure Certificates
-----------------------
-
-Now you edit the config file ``~/synapse/homeserver.yaml`` to reflect the paths to the letsencrypt certificates:
-
-.. code-block:: yaml
-
-    tls_certificate_path: "/home/isabell/etc/certificates/my.domain.name.crt"
-
-    tls_private_key_path: "/home/isabell/etc/certificates/my.domain.name.key"
 
 Configure Database Access
 -------------------------

--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -179,7 +179,6 @@ This has to be made available under ``/.well-known/matrix`` via the web backend:
   Set backend for /.well-known/matrix to apache.
   [isabell@stardust ~]$
 
-
 Configure Database Access
 -------------------------
 


### PR DESCRIPTION
TLS certificates are not used in reverse-proxy setup, because nginx is already handling TLS. See also hint in the generated config file

 ```
listeners:
   # TLS-enabled listener: for when matrix traffic is sent directly to synapse.
   #
   # Disabled by default. To enable it, uncomment the following. (Note that you
   # will also need to give Synapse a TLS key and certificate: see the TLS section
   # below.)
   #
   #- port: 8448
   #  type: http
   #  tls: true
   #  resources:
   #    - names: [client, federation]
```

which states that TLS needs to be configured *if* this listener were enabled