### PR TITLE
[bitwarden_rs] update guide to fix cargo build issue

### DIFF
--- a/source/guide_bitwarden.rst
+++ b/source/guide_bitwarden.rst
@@ -57,6 +57,75 @@ If you want to use Bitwarden_rs with your own domain you need to setup your doma
 Installation
 ============
 
+Install Rust
+-------------------
+
+.. note:: Since we need the rust nightly release channel for the installation, but Uberspace currently only provides the :manual:`stable release <lang-rust>`, we have to install it ourselves.
+
+To compile the project, we need to install the `rust toolchain`_. Install it via rustup and use the following configuration when asked:
+
+ * Enter ``2`` to customize the installation.
+ * Press ``Enter`` to use the host triple as default.
+ * Type ``nightly`` as default toolchain as it is required for bitwarden_rs.
+ * Type ``default`` to use the default install profile. 
+ * Enter ``y`` to add rust  to the PATH.
+ * Enter ``1`` to proceed with the installation
+
+.. code-block:: console
+ :emphasize-lines: 16,21,24,27,30,42
+
+ [isabell@stardust ~]$ curl https://sh.rustup.rs -sSf | sh
+ info: downloading installer
+
+ Welcome to Rust!
+ [...]
+ Current installation options:
+ 
+   default host triple: x86_64-unknown-linux-gnu
+     default toolchain: nightly
+               profile: default
+  modify PATH variable: yes
+
+ 1) Proceed with installation (default)
+ 2) Customize installation
+ 3) Cancel installation
+ >	2
+
+ I'm going to ask you the value of each of these installation options.
+ You may simply press the Enter key to leave unchanged.
+
+ Default host triple?
+
+ Default toolchain? (stable/beta/nightly/none)
+	nightly
+
+ Profile (which tools and data to install)? (minimal/default/complete)
+	default
+
+ Modify PATH variable? (y/n)
+	y
+
+ Current installation options:
+
+   default host triple: x86_64-unknown-linux-gnu
+     default toolchain: nightly
+               profile: default
+  modify PATH variable: yes
+
+ 1) Proceed with installation (default)
+ 2) Customize installation
+ 3) Cancel installation
+ >	1
+ [...]
+ Rust is installed now. Great!
+
+
+To finish the setup, **logout and login** again or run
+
+.. code-block:: console
+
+ [isabell@stardust ~]$ source $HOME/.cargo/env
+
 Install Bitwarden_rs
 --------------------
 


### PR DESCRIPTION
Hi!

in #609 @luto [told me that](https://github.com/Uberspace/lab/pull/609#issuecomment-629205490) Uberspace will support Rust in the Version 7.6.2, which is indeed correct - but only the `stable `release channel. **Bitwarden_rs** depends on the nightly release channel, so as described right now in the guide `cargo build -j 1 --release --features sqlite` will fail.

> Compiling pear_codegen v0.1.4
> error: failed to run custom build command for `pear_codegen v0.1.4`
> 
> Caused by:
>   process didn't exit successfully: `/home/passres/bitwarden_rs/target/release/b                               uild/pear_codegen-eb17718987529976/build-script-build` (exit code: 101)
> --- stderr
> Error: Pear requires a 'dev' or 'nightly' version of rustc.

Therefore I re-added the rust-installation section to the guide to fix this issue.

Another solution would be to include also the `nightly `and/or `dev `release channels to the default uberspace installation.

Looking forward for your Feedback to solve this issue.


