### PR TITLE
Replace /home/isabell/ with $HOME

### DIFF
--- a/source/guide_bludit.rst
+++ b/source/guide_bludit.rst
@@ -122,7 +122,7 @@ Update
  bl-content/
  […]
  README.md
- [isabell@stardust html]$ mv 3.8.0_backup.tar.gz /home/isabell/
+ [isabell@stardust html]$ mv 3.8.0_backup.tar.gz $HOME
  [isabell@stardust html]$
 
 2. Download the latest version from Bludit_ or Github_. In this example we´re download it from Github_.

--- a/source/guide_ezmlm.rst
+++ b/source/guide_ezmlm.rst
@@ -102,7 +102,7 @@ The test call should show that everything is OK. Now create directories and inst
 
 ::
 
- [isabell@stardust ezmlm-idx-7.2.2] mkdir -p /home/isabell/lib /home/isabell/etc
+ [isabell@stardust ezmlm-idx-7.2.2] mkdir -p $HOME/{lib,etc}
  [isabell@stardust ezmlm-idx-7.2.2] make install
  [...]
  [isabell@stardust ezmlm-idx-7.2.2]

--- a/source/guide_flatboard.rst
+++ b/source/guide_flatboard.rst
@@ -118,7 +118,7 @@ Updates
  data/
  […]
  data/key.php
- [isabell@stardust html]$ mv flatforum-data_backup.tar.gz /home/isabell/
+ [isabell@stardust html]$ mv flatforum-data_backup.tar.gz $HOME
  [isabell@stardust html]$
 
 2. Download the latest version from Flatboard_.

--- a/source/guide_ioncube.rst
+++ b/source/guide_ioncube.rst
@@ -83,7 +83,7 @@ Create the following configuration directive if you are using PHP 5.6.
 
 ::
 
-  [isabell@stardust ~]$ echo 'zend_extension=/home/isabell/ioncube/ioncube_loader_lin_5.6.so' > etc/php.early.d/ioncube.ini
+  [isabell@stardust ~]$ echo "zend_extension=$HOME/ioncube/ioncube_loader_lin_5.6.so" > etc/php.early.d/ioncube.ini
   [isabell@stardust ~]$
 
 
@@ -95,7 +95,7 @@ Create the following configuration directive if you are using PHP 7.0.
 
 ::
 
-  [isabell@stardust ~]$ echo 'zend_extension=/home/isabell/ioncube/ioncube_loader_lin_7.0.so' > etc/php.early.d/ioncube.ini
+  [isabell@stardust ~]$ echo "zend_extension=$HOME/ioncube/ioncube_loader_lin_7.0.so" > etc/php.early.d/ioncube.ini
   [isabell@stardust ~]$
 
 
@@ -107,7 +107,7 @@ Create the following configuration directive if you are using PHP 7.1.
 
 ::
 
-  [isabell@stardust ~]$ echo 'zend_extension=/home/isabell/ioncube/ioncube_loader_lin_7.1.so' > etc/php.early.d/ioncube.ini
+  [isabell@stardust ~]$ echo "zend_extension=$HOME/ioncube/ioncube_loader_lin_7.1.so" > etc/php.early.d/ioncube.ini
   [isabell@stardust ~]$
 
 
@@ -119,7 +119,7 @@ Create the following configuration directive if you are using PHP 7.2.
 
 ::
 
-  [isabell@stardust ~]$ echo 'zend_extension=/home/isabell/ioncube/ioncube_loader_lin_7.2.so' > etc/php.early.d/ioncube.ini
+  [isabell@stardust ~]$ echo "zend_extension=$HOME/ioncube/ioncube_loader_lin_7.2.so" > etc/php.early.d/ioncube.ini
   [isabell@stardust ~]$
 
 

--- a/source/guide_taskd.rst
+++ b/source/guide_taskd.rst
@@ -72,7 +72,7 @@ remember this port. To connect later, we'll also need to know the hostname:
 We need a directory where the taskd files are stored.
 ::
 
- [isabell@stardust ~]$ export TASKDDATA=/home/isabell/.var/taskddata
+ [isabell@stardust ~]$ export TASKDDATA=$HOME/.var/taskddata
  [isabell@stardust ~]$ mkdir -p $TASKDDATA
  [isabell@stardust ~]$
 
@@ -104,8 +104,8 @@ Install Required taskd Binaries
 -------------------------------
 ::
 
- [isabell@stardust ~]$ cp /home/isabell/taskd-1.1.0/src/taskd /home/isabell/bin
- [isabell@stardust ~]$ cp /home/isabell/taskd-1.1.0/src/taskdctl /home/isabell/bin
+ [isabell@stardust ~]$ cp $HOME/taskd-1.1.0/src/taskd $HOME/bin
+ [isabell@stardust ~]$ cp $HOME/taskd-1.1.0/src/taskdctl $HOME/bin
  [isabell@stardust ~]$
 
 Verify installation:
@@ -138,7 +138,7 @@ Create Server PKI Certificates and key
 The taskd bundles scripts for generating required keys and certificates for everything in the pki directory. We can set all required information in the vars file. But first we follow the recommended step and copy the pki directory to the ``$TASKDDATA`` directory so we have everything in one place.
 ::
 
- [isabell@stardust ~]$ cp -r /home/isabell/taskd-1.1.0/pki $TASKDDATA
+ [isabell@stardust ~]$ cp -r $HOME/taskd-1.1.0/pki $TASKDDATA
  [isabell@stardust ~]$ cd $TASKDDATA/pki
  [isabell@stardust ~]$
 
@@ -276,10 +276,10 @@ Configuring the Client
 Now Isabell wants to sync all her devices. Copy four files to all her devices:
 ::
 
- [isabell@othermachine ~]$ scp /home/isabell/.var/taskddata/pki/ca.cert.pem isabell@othermachine:~/.task/
- [isabell@othermachine ~]$ scp /home/isabell/.var/taskddata/pki/Isabell_Smith.cert.pem isabell@othermachine:~/.task/
- [isabell@othermachine ~]$ scp /home/isabell/.var/taskddata/pki/Isabell_Smith.key.pem isabell@othermachine:~/.task/
- [isabell@othermachine ~]$ scp /home/isabell/.var/taskddata/pki/Isabell_task_info isabell@othermachine:~/.task/
+ [isabell@othermachine ~]$ scp $HOME/.var/taskddata/pki/ca.cert.pem isabell@othermachine:~/.task/
+ [isabell@othermachine ~]$ scp $HOME/.var/taskddata/pki/Isabell_Smith.cert.pem isabell@othermachine:~/.task/
+ [isabell@othermachine ~]$ scp $HOME/.var/taskddata/pki/Isabell_Smith.key.pem isabell@othermachine:~/.task/
+ [isabell@othermachine ~]$ scp $HOME/.var/taskddata/pki/Isabell_task_info isabell@othermachine:~/.task/
  [isabell@othermachine ~]$
 
 


### PR DESCRIPTION
Using $HOME instead of '/home/isabell/' makes snippets more friendly for copy-paste workflows.
The replacement was done only in snippets of Bash code.