### PR TITLE
[PostgreSQL] Fixes a spelling mistake

### DIFF
--- a/source/guide_postgresql.rst
+++ b/source/guide_postgresql.rst
@@ -215,7 +215,7 @@ PostgreSQL Configuration
 
 Edit ``~/opt/postgresql/data/postgresql.conf`` and set the key values ``listen_adresses``, ``port`` and ``unix_socket_directories``:
 
-.. warning:: Replace replace ``<username>`` with your username!
+.. warning:: Please replace ``<username>`` with your username!
 
 .. code-block:: postgres
  :emphasize-lines: 7,14


### PR DESCRIPTION
"Replace replace" makes no sense. Therefore changed to "Please replace" as it is also shown in other parts of the manual.