### PR TITLE
[CONTRIBUTING.md] add note on commit feeds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,10 @@ Before you begin writing:
 
  - To signify intent and prevent duplicate work, please create an issue **before** working on your pull request.
  - Check out our [style guide](https://github.com/Uberspace/lab/blob/master/STYLE.md).
- 
+
+If you want to stay informed of changes to your guide or a guide in your interest you can subscribe to its commit feed.  
+e.g. for Nextcloud it would be: https://github.com/Uberspace/lab/commits/master/source/guide_nextcloud.rst.atom
+
 ## Reward
 
 For every guide that makes it to the Uberlab you get an Uberspace mug that you can't buy anywhere:


### PR DESCRIPTION
> If you want to stay informed of changes to your guide or a guide in your interest you can subscribe to its commit feed.  
> e.g. for Nextcloud it would be: https://github.com/Uberspace/lab/commits/master/source/guide_nextcloud.rst.atom

I think some contributors would like to watch changes to a specific guide as they may not like the default flood of watch notifications by GitHub.

I'm not sure if this is the right place for this information. Maybe each guide could also have such an information like the "View Changelog" link.