### PR TITLE
do not assume ~/html to be empty

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -11,7 +11,8 @@ Please follow our rules to keep the guides maintainable and consistent.
  * Always use the same username `isabell`.
  * Always use the same hostname `stardust`. For bash snippets, use `[isabell@stardust ~]$`.
  * Always use full paths in commands. Don't assume the home directory or the html folder.
- * Don't mention additional document roots. *Keep it simple*. Don't use subfolders. Always use the standard document root `~/html`. Always assume the document root is empty.
+ * Don't mention additional document roots. *Keep it simple*. Don't use subfolders inside `~/html`.
+ * Always use the standard document root `~/html`. Do not delete it but move it away using `mv html html.old`, after `cd`ing into `/var/www/virtual/$USER`.
  * Use the templates in `source/includes/` where appropriate.
  For example `.. include:: includes/web-domain-list.rst` generates the following snippet:
  ```

--- a/source/guide_baikal.rst
+++ b/source/guide_baikal.rst
@@ -51,7 +51,7 @@ Remove your ``html`` directory and download the current version of Baïkal from 
 .. code-block:: console
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ wget https://github.com/sabre-io/Baikal/releases/download/0.6.1/baikal-0.6.1.zip
  [isabell@stardust isabell]$ unzip baikal-0.6.1.zip
  [isabell@stardust isabell]$ rm baikal-0.6.1.zip

--- a/source/guide_bookstack.rst
+++ b/source/guide_bookstack.rst
@@ -119,7 +119,7 @@ Remove your unused :manual:`DocumentRoot <web-documentroot>` and create a new sy
 .. code-block:: console
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/BookStack/public html
  [isabell@stardust isabell]$
 

--- a/source/guide_contao.rst
+++ b/source/guide_contao.rst
@@ -81,7 +81,7 @@ Create a folder for Contao Manager, download it and make it accessible:
  [isabell@stardust web]$ wget https://download.contao.org/contao-manager/stable/contao-manager.phar
  [isabell@stardust web]$ mv contao-manager.phar contao-manager.phar.php
  [isabell@stardust web]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/<target>/web/ html
  [isabell@stardust isabell]$
 
@@ -126,7 +126,7 @@ Next, remove the unused :manual:`DocumentRoot <web-documentroot>` and create a n
  :emphasize-lines: 1,3
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/<target>/web/ html
  [isabell@stardust isabell]$
 

--- a/source/guide_drupal.rst
+++ b/source/guide_drupal.rst
@@ -123,7 +123,7 @@ symbolic link to make it accessible to the web.
 
 .. code-block:: console
 
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/drupal/web/ html
  [isabell@stardust isabell]$
 

--- a/source/guide_flarum.rst
+++ b/source/guide_flarum.rst
@@ -55,7 +55,7 @@ We create the database and install Flarum using composer.
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
  [isabell@stardust isabell]$ composer create-project flarum/flarum flarum --stability=beta
  […]
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s flarum html
  [isabell@stardust isabell]$
 

--- a/source/guide_freshrss.rst
+++ b/source/guide_freshrss.rst
@@ -81,7 +81,7 @@ Now remove your ``html`` directory and create a symbolic link ``html -> FreshRSS
 
 ::
 
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s FreshRSS-master/p/ html
  [isabell@stardust isabell]$ ls -l
  total 2636

--- a/source/guide_grocy.rst
+++ b/source/guide_grocy.rst
@@ -75,7 +75,7 @@ DocumentRoot to grocy's public folder:
 
 ::
 
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s grocy/public html
  [isabell@stardust isabell]$
 

--- a/source/guide_invoiceninja.rst
+++ b/source/guide_invoiceninja.rst
@@ -78,7 +78,7 @@ Remove your empty :manual:`DocumentRoot <web-documentroot>` and create a new sym
 .. code-block:: console
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/invoiceninja/public html
  [isabell@stardust ~]$
 

--- a/source/guide_kimai.rst
+++ b/source/guide_kimai.rst
@@ -88,7 +88,7 @@ Remove your unused :manual:`DocumentRoot <web-documentroot>` and create a new sy
 ::
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/kimai2/public html
  [isabell@stardust ~]$
 

--- a/source/guide_neos.rst
+++ b/source/guide_neos.rst
@@ -84,7 +84,7 @@ Remove your unused :manual:`DocumentRoot <web-documentroot>` and create a new sy
 ::
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/Neos/Web html
  [isabell@stardust isabell]$
 

--- a/source/guide_pixelfed.rst
+++ b/source/guide_pixelfed.rst
@@ -101,7 +101,7 @@ Remove your empty DocumentRoot and create a new symbolic link to the ``pixelfed/
 ::
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/pixelfed/public html
  [isabell@stardust isabell]$
 

--- a/source/guide_shopware-6.rst
+++ b/source/guide_shopware-6.rst
@@ -79,7 +79,7 @@ you need to remove your DocumentRoot and create a symlink to the shopware/public
 
 .. code-block:: console
 
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/shopware/public html
  [isabell@stardust isabell]$
 

--- a/source/guide_sulu.rst
+++ b/source/guide_sulu.rst
@@ -77,7 +77,7 @@ Remove your empty :manual:`DocumentRoot <web-documentroot>` and create a new sym
 
 .. code-block:: console
 
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/sulucms/public html
  [isabell@stardust isabell]$ cd ~
  [isabell@stardust ~]$

--- a/source/guide_typo3-cms.rst
+++ b/source/guide_typo3-cms.rst
@@ -81,7 +81,7 @@ Now remove the :manual:`document root <web-documentroot>` and create a symlink t
 ::
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/
- [isabell@stardust isabell]$ rmdir html
+ [isabell@stardust isabell]$ mv html html.old
  [isabell@stardust isabell]$ ln -s /var/www/virtual/$USER/typo3-cms/public html
  [isabell@stardust isabell]$
 

--- a/source/guide_wordpress.rst
+++ b/source/guide_wordpress.rst
@@ -65,7 +65,10 @@ You will need to enter the following information:
 .. code-block:: console
  :emphasize-lines: 1,6,10
 
- [isabell@stardust ~]$ cd /var/www/virtual/$USER/html/
+ [isabell@stardust ~]$ cd /var/www/virtual/$USER/
+ [isabell@stardust isabell]$ mv html html.old
+ [isabell@stardust isabell]$ mkdir html
+ [isabell@stardust isabell]$ cd html
  [isabell@stardust html]$ wp core download
  Downloading WordPress 23.42.1 (en_US)...
  md5 hash verified: f009061b9d24854bfdc999c7fbeb7579


### PR DESCRIPTION
Because it will contain an explanatory `index.html` in future releases. So do not delete it, but just move it away.

Alternatively change this to `rm html/index.html; rmdir html` to make it clearer what is happening?