### PR TITLE
added a note for failed mailman installation

### DIFF
--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -66,6 +66,15 @@ Get Mailman 3
 -------------
 Install Mailman 3 and its dependencies via pip.
 
+
+.. note:: In the case that the mailman installation fails with an import error like ``ImportError: cannot import name 'find_namespace_packages'`` on installations this is due to an outdated version of the ``setuptools`` package. It can be upgraded to a newer version for your user using pip itself:
+
+ .. code :: bash
+
+  [isabell@stardust ~]$ pip3.6 install --user --upgrade setuptools wheel
+ [...]
+ [isabell@stardust ~]$
+
 ::
 
  [isabell@stardust ~]$ pip3.6 install --user mailman hyperkitty postorius mailman-hyperkitty whoosh


### PR DESCRIPTION
some package required by mailman (`flufl.i18n`) requires a newer version of `setuptools`, which leads to non-trivial failure of the installation. This commit includes a hint how to update the respective package.