### PR TITLE
[baikal] add info when installing to subdirectory

### DIFF
--- a/source/guide_baikal.rst
+++ b/source/guide_baikal.rst
@@ -58,8 +58,12 @@ Remove your ``html`` directory and download the current version of Baïkal from 
  [isabell@stardust isabell]$ ln -s baikal/html html
  [isabell@stardust isabell]$
 
+You can also choose not to replace your ``html`` directory (and e.g. install Baïkal in a subdirectory or under a subdomain). In that case, you need to perform additional configuration steps. 
+
 Configuration
 =============
+
+Only if you didn't replace your ``html`` directory (and e.g. installed Baïkal in a subdirectory or under a subdomain), edit the file ``baikal/config/baikal.yaml`` and set the value of ``base_uri`` to ``'/'``.
 
 After the installation you need to open isabell.uber.space in your browser to finish your setup.
 


### PR DESCRIPTION
When Baïkal is not installed directly into the `html` DocumentRoot, PHP will throw warnings in the form:
```
LogicException: Requested uri (/dav.php) is out of base uri (/<username>.uber.space/dav.php/) in /var/www/virtual/<username>/baikal/vendor/sabre/http/lib/Request.php:184
```
when a WebDAV client tries to connect.

This can be fixed by editing the configuration file and setting the base URL.