### PR TITLE
[akaunting] Remove PHP version from Akaunting guide

### DIFF
--- a/source/guide_akaunting.rst
+++ b/source/guide_akaunting.rst
@@ -43,14 +43,6 @@ Akaunting is released under the GPLv3_ license. The licence can be found in the 
 Prerequisites
 =============
 
-We're using PHP_ in the stable version 7.1:
-
-::
-
- [isabell@stardust ~]$ uberspace tools version show php
- Using 'PHP' version: '7.1'
- [isabell@stardust ~]$
-
 .. include:: includes/my-print-defaults.rst
 
 Your domain needs to be set up:


### PR DESCRIPTION
https://akaunting.com/docs/requirements
Akaunting requires "PHP 7.2.5 or higher". Since 7.2 is the oldest available version, I think we can just drop the notice about the requirement. I could also update it to 7.4 and mention that anything 7.2 or above should work, if that'd be better.