### PR TITLE
[open-port] Fix syntax highlighting

### DIFF
--- a/source/includes/open-port.rst
+++ b/source/includes/open-port.rst
@@ -1,8 +1,9 @@
 To make the application accessible from the outside, open a `port in the firewall <firewall_>`_:
 
-.. code-block:: bash
+.. code-block:: console
+ :emphasize-lines: 1
 
- [isabell@stardust ~] uberspace port add
+ [isabell@stardust ~]$ uberspace port add
  Port 40132 will be open for TCP and UDP traffic in a few minutes.
  [isabell@stardust ~]$
 


### PR DESCRIPTION
Upon writing a guide we noticed syntax highlighting in the "open-port" include differs from other code blocks. It uses code-block [bash](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashLexer), which is intended for bash scripts, but not for bash sessions. This PR changes it to [console](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashSessionLexer).