### PR TITLE
[Shiori] Add Shiori install guide

### DIFF
--- a/source/_static/images/shiori.svg
+++ b/source/_static/images/shiori.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg5296"
+   version="1.1"
+   viewBox="0 0 117.17262 117.17262"
+   height="117.17262mm"
+   width="117.17262mm">
+  <defs
+     id="defs5290" />
+  <metadata
+     id="metadata5293">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(-39.6875,-207.41964)"
+     id="layer1">
+    <ellipse
+       ry="58.586308"
+       rx="58.586311"
+       cy="266.00595"
+       cx="98.273811"
+       id="path5277"
+       style="opacity:1;fill:#f44336;fill-opacity:1;stroke:none;stroke-width:0.35299999;stroke-miterlimit:4;stroke-dasharray:0.353, 0.70599999;stroke-dashoffset:0;stroke-opacity:1" />
+    <g
+       transform="translate(1.9099648,5.9277343e-6)"
+       id="text819"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:81.49136353px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.26458329"
+       aria-label="栞 ">
+      <path
+         id="path5851"
+         style="font-style:normal;font-variant:normal;font-weight:300;font-stretch:normal;font-size:81.4916687px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro, Light';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke-width:0.26458329"
+         d="m 61.029568,268.55256 h 32.15101 v -7.63984 h 6.366536 v 7.63984 H 131.3798 v 5.72988 h -28.01276 q 11.77809,12.09642 29.92272,18.14463 l -3.5016,6.68487 q -18.14463,-7.32152 -30.241046,-21.96455 v 24.51116 h -6.366536 v -24.82949 q -10.823113,13.36973 -29.604396,21.64622 l -4.138249,-5.41155 q 17.826303,-7.00319 28.649415,-18.78129 H 61.029568 Z M 77.90089,236.08322 H 64.531163 v -5.72988 h 29.922722 v 5.72988 H 83.949099 v 8.59483 h 10.823113 v 5.72988 H 83.949099 q -1.273307,10.82311 -14.324707,17.8263 l -3.501595,-5.41155 q 10.504785,-5.09323 11.459766,-12.41475 H 62.621202 v -5.72988 H 77.90089 Z m 21.00957,-5.72988 h 31.51436 v 5.72988 h -13.68806 v 8.59483 h 15.27969 v 5.72988 h -15.27969 v 17.18965 h -6.04821 V 250.40793 H 98.273807 v -5.72988 h 12.414743 v -8.59483 H 98.91046 Z" />
+    </g>
+  </g>
+</svg>

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -1,0 +1,119 @@
+.. author:: Kevin <https://github.com/systemsemaphore>
+
+.. tag:: lang-go
+
+.. tag:: web
+
+.. highlight:: console
+
+.. sidebar:: Logo
+
+  .. image:: _static/images/shiori.svg
+      :align: center
+
+######
+Shiori
+######
+
+.. tag_list::
+
+Shiori_ is a simple bookmarks manager written in Go and distributed under the MIT License. It can be used as a `command line application <https://github.com/go-shiori/shiori/wiki/Usage#using-command-line-interface>` or via the built-in web-ui.
+
+----
+
+.. note:: For this guide you should be familiar with the basic concepts of
+
+  * :manual:`supervisord <daemons-supervisord>`
+
+Prerequisites
+=============
+
+.. note:: By default, Shiori runs on port 8080.
+
+Shiori can run under a subdomain (e.g. https://shiori.isabell.uber.space) or via a subpath (e.g. 
+https://isabell.uber.space/shiori/).
+
+For both options you need to configure a `web backend <webbackend_>`_.
+The subpath option looks like this:
+
+::
+
+  [isabell@stardust ~]$ uberspace web backend set /shiori/ --http --port 8080 --remove-prefix
+  Set backend for / to port 8080; please make sure something is listening!
+  You can always check the status of your backend using "uberspace web backend list".
+  [isabell@stardust ~]$
+
+.. _webbackend: https://manual.uberspace.de/web-backends.html
+
+Note the `--remove-prefix` option here. Without it, Shiori will not work behind a sub path (e.g. `isabell.uber.space/shiori/`).
+
+
+Installation
+============
+
+Like a lot of Go software, Shiori is distributed as a single binary. Download Shiori's latest `release <https://github.com/go-shiori/shiori/releases/latest>`_ and make sure that the file can be executed.
+
+::
+
+  [isabell@stardust ~]$ mkdir ~/shiori && cd ~/shiori
+  [isabell@stardust shiori~]$ wget https://github.com/go-shiori/shiori/releases/download/v1.5.0/shiori-linux-amd64-stretch
+  Resolving github.com (github.com)... 140.82.121.3
+  Connecting to github.com (github.com)|140.82.121.3|:443... connected.
+  HTTP request sent, awaiting response... 302 Found
+  Length: 19735216 (19M) [application/octet-stream]
+  Saving to: ‘shiori-linux-amd64-stretch’
+
+ 100%[======================================>] 19,735,216  12.2MB/s
+
+  2020-11-11 22:04:39 (12.2 MB/s) - ‘shiori-linux-amd64-stretch’ saved [19735216/19735216]
+  [isabell@stardust shiori~]$ chmod u+x shiori-linux-amd64-stretch
+  [isabell@stardust shiori]$
+
+
+Configuration
+=============
+
+Setup daemon
+-----------
+
+.. note:: To use a different port instead of 8080, you need to add `` -p <portnumber>`` to the command in your shiori.ini file
+
+Create ``~/etc/services.d/shiori.ini`` with the following content.
+
+.. code-block:: ini
+
+  [program:shiori]
+  command=/home/isabell/shiori/shiori-linux-amd64-stretch serve
+  autostart=yes
+  autorestart=yes
+
+.. include:: includes/supervisord.rst
+
+If it's not in state RUNNING, check your configuration.
+
+Finishing installation
+======================
+
+The default user and password is ``shiori`` and ``gopher``.
+Once logged in you will be able to use the web interface. To add a new account,
+open the settings page and click on "Add new account".
+With this, the default user will be deactivated automatically.
+
+Updates
+=======
+
+.. note:: Check the update feed_ regularly to stay informed about the newest version.
+
+Check Shiori's `releases <https://github.com/go-shiori/shiori/release>`_ for the latest version. If a newer
+version is available, stop daemon by ``supervisorctl stop shiori`` and repeat the "Installation" step followed by ``supervisorctl start shiori`` to restart Shiori.
+
+.. _Shiori: https://github.com/go-shiori/shiori#readme
+.. _Documentation: https://github.com/go-shiori/shiori/tree/master/docs/
+.. _feed: https://github.com/go-shiori/shiori/releases/
+.. _Dashboard: https://uberspace.de/dashboard/authentication
+
+----
+
+Tested (to some extent) with Shiori 1.5.0, Uberspace 7.7.9.0
+
+.. author_list::

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -1,4 +1,4 @@
-.. author:: Kevin <https://github.com/systemsemaphore>
+.. author:: Kevin Jost <https://github.com/systemsemaphore>
 
 .. tag:: lang-go
 

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -40,7 +40,7 @@ To reach it, you need to configure a `web backend <webbackend_>`_.
   You can always check the status of your backend using "uberspace web backend list".
   [isabell@stardust ~]$
 
-.. _webbackend: https://manual.uberspace.de/web-backends.html
+.. include:: includes/web-backend.rst
 
 Installation
 ============
@@ -49,19 +49,18 @@ Like a lot of Go software, Shiori is distributed as a single binary. Download Sh
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ mkdir ~/shiori && cd ~/shiori
-  [isabell@stardust shiori]$ wget https://github.com/go-shiori/shiori/releases/download/v1.5.0/shiori-linux-amd64-stretch
+  [isabell@stardust ~]$ wget https://github.com/go-shiori/shiori/releases/download/v1.5.0/shiori-linux-amd64-stretch -O ~/bin/shiori
   Resolving github.com (github.com)... 140.82.121.3
   Connecting to github.com (github.com)|140.82.121.3|:443... connected.
   HTTP request sent, awaiting response... 302 Found
   Length: 19735216 (19M) [application/octet-stream]
-  Saving to: ‘shiori-linux-amd64-stretch’
+  Saving to: ‘/home/shiori/bin/shiori’
 
  100%[======================================>] 19,735,216  12.2MB/s
 
-  2020-11-11 22:04:39 (12.2 MB/s) - ‘shiori-linux-amd64-stretch’ saved [19735216/19735216]
-  [isabell@stardust shiori]$ chmod u+x shiori-linux-amd64-stretch
-  [isabell@stardust shiori]$
+  2020-11-11 22:04:39 (12.2 MB/s) - ‘/home/isabell/bin/shiori’ saved [19735216/19735216]
+  [isabell@stardust ~]$ chmod u+x ~/bin/shiori
+  [isabell@stardust ~]$
 
 Configuration
 =============

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -23,7 +23,7 @@ Shiori_ is a simple bookmarks manager written in Go and distributed under the MI
 .. note:: For this guide you should be familiar with the basic concepts of
 
   * :manual:`supervisord <daemons-supervisord>`
-  * :manual:`web backends <webbackend_>`_.
+  * :manual:`web backends <web-backends>`
 
 Prerequisites
 =============

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -47,7 +47,7 @@ Installation
 
 Like a lot of Go software, Shiori is distributed as a single binary. Download Shiori's latest `release <https://github.com/go-shiori/shiori/releases/latest>`_ and make sure that the file can be executed.
 
-::
+.. code-block:: console
 
   [isabell@stardust ~]$ mkdir ~/shiori && cd ~/shiori
   [isabell@stardust shiori]$ wget https://github.com/go-shiori/shiori/releases/download/v1.5.0/shiori-linux-amd64-stretch

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -76,7 +76,7 @@ Create ``~/etc/services.d/shiori.ini`` with the following content.
 .. code-block:: ini
 
   [program:shiori]
-  command=/home/isabell/shiori/shiori-linux-amd64-stretch serve
+  command=shiori serve
   autostart=yes
   autorestart=yes
 

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -28,17 +28,7 @@ Shiori_ is a simple bookmarks manager written in Go and distributed under the MI
 Prerequisites
 =============
 
-.. note:: Shiori won't work with a subpath (e.g. https://isabell.uber.space/shiori/).
-
-By default, Shiori runs on port 8080.
-To reach it, you need to configure a `web backend <webbackend_>`_.
-
-::
-
-  [isabell@stardust ~]$ uberspace web backend set / --http --port 8080
-  Set backend for / to port 8080; please make sure something is listening!
-  You can always check the status of your backend using "uberspace web backend list".
-  [isabell@stardust ~]$
+.. note:: By default, Shiori runs on port 8080.
 
 .. include:: includes/web-backend.rst
 

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -1,10 +1,9 @@
+.. highlight:: console
+
 .. author:: Kevin Jost <https://github.com/systemsemaphore>
 
 .. tag:: lang-go
-
 .. tag:: web
-
-.. highlight:: console
 
 .. sidebar:: Logo
 
@@ -17,36 +16,31 @@ Shiori
 
 .. tag_list::
 
-Shiori_ is a simple bookmarks manager written in Go and distributed under the MIT License. It can be used as a `command line application <https://github.com/go-shiori/shiori/wiki/Usage#using-command-line-interface>` or via the built-in web-ui.
+Shiori_ is a simple bookmarks manager written in Go and distributed under the MIT License. It can be used as a `command line application <https://github.com/go-shiori/shiori/wiki/Usage#using-command-line-interface>`_ or via the built-in web-ui.
 
 ----
 
 .. note:: For this guide you should be familiar with the basic concepts of
 
   * :manual:`supervisord <daemons-supervisord>`
+  * :manual:`web backends <webbackend_>`_.
 
 Prerequisites
 =============
 
-.. note:: By default, Shiori runs on port 8080.
+.. note:: Shiori won't work with a subpath (e.g. https://isabell.uber.space/shiori/).
 
-Shiori can run under a subdomain (e.g. https://shiori.isabell.uber.space) or via a subpath (e.g. 
-https://isabell.uber.space/shiori/).
-
-For both options you need to configure a `web backend <webbackend_>`_.
-The subpath option looks like this:
+By default, Shiori runs on port 8080.
+To reach it, you need to configure a `web backend <webbackend_>`_.
 
 ::
 
-  [isabell@stardust ~]$ uberspace web backend set /shiori/ --http --port 8080 --remove-prefix
+  [isabell@stardust ~]$ uberspace web backend set / --http --port 8080
   Set backend for / to port 8080; please make sure something is listening!
   You can always check the status of your backend using "uberspace web backend list".
   [isabell@stardust ~]$
 
 .. _webbackend: https://manual.uberspace.de/web-backends.html
-
-Note the `--remove-prefix` option here. Without it, Shiori will not work behind a sub path (e.g. `isabell.uber.space/shiori/`).
-
 
 Installation
 ============
@@ -69,14 +63,13 @@ Like a lot of Go software, Shiori is distributed as a single binary. Download Sh
   [isabell@stardust shiori~]$ chmod u+x shiori-linux-amd64-stretch
   [isabell@stardust shiori]$
 
-
 Configuration
 =============
 
 Setup daemon
 -----------
 
-.. note:: To use a different port instead of 8080, you need to add ``-p <portnumber>`` to the command in your shiori.ini file
+.. note:: To use a different port instead of 8080, you need to add ``-p <portnumber>`` to the command in your ``shiori.ini`` file. Remember to adjust the port for the web backend as well.
 
 Create ``~/etc/services.d/shiori.ini`` with the following content.
 
@@ -114,6 +107,6 @@ version is available, stop daemon by ``supervisorctl stop shiori`` and repeat th
 
 ----
 
-Tested (to some extent) with Shiori 1.5.0, Uberspace 7.7.9.0
+Tested with Shiori 1.5.0, Uberspace 7.7.9.0
 
 .. author_list::

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -60,7 +60,7 @@ Like a lot of Go software, Shiori is distributed as a single binary. Download Sh
  100%[======================================>] 19,735,216  12.2MB/s
 
   2020-11-11 22:04:39 (12.2 MB/s) - ‘shiori-linux-amd64-stretch’ saved [19735216/19735216]
-  [isabell@stardust shiori~]$ chmod u+x shiori-linux-amd64-stretch
+  [isabell@stardust shiori]$ chmod u+x shiori-linux-amd64-stretch
   [isabell@stardust shiori]$
 
 Configuration

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -50,7 +50,7 @@ Like a lot of Go software, Shiori is distributed as a single binary. Download Sh
 ::
 
   [isabell@stardust ~]$ mkdir ~/shiori && cd ~/shiori
-  [isabell@stardust shiori~]$ wget https://github.com/go-shiori/shiori/releases/download/v1.5.0/shiori-linux-amd64-stretch
+  [isabell@stardust shiori]$ wget https://github.com/go-shiori/shiori/releases/download/v1.5.0/shiori-linux-amd64-stretch
   Resolving github.com (github.com)... 140.82.121.3
   Connecting to github.com (github.com)|140.82.121.3|:443... connected.
   HTTP request sent, awaiting response... 302 Found

--- a/source/guide_shiori.rst
+++ b/source/guide_shiori.rst
@@ -76,7 +76,7 @@ Configuration
 Setup daemon
 -----------
 
-.. note:: To use a different port instead of 8080, you need to add `` -p <portnumber>`` to the command in your shiori.ini file
+.. note:: To use a different port instead of 8080, you need to add ``-p <portnumber>`` to the command in your shiori.ini file
 
 Create ``~/etc/services.d/shiori.ini`` with the following content.
 


### PR DESCRIPTION
Hello all,
I need help with this guide before #837 can be closed.

I've written guide_shiori.rst (my first guide) based on guide_gotify.rst. I have successfully tested

- [x] installation

- [x] configuration (setting up a daemon)

- [x] accessing the web-ui and logging in

- [x] creating a new account

- [x] creating a bookmark

- [x] ~~However, I didn't manage to get it up and running behind a sub path~~ Sub path doesn't work yet, see go-shiori/shiori#39

It's working with [https://shiori.uber.space](https://shiori.uber.space) and `uberspace web backend set / --http --port 8080` right now. ~~I've tried `uberspace web backend set /shiori/ --http --port 8080` with and without `--remove-prefix` before, both fail with error 404. Help would be appreciated.~~