### PR TITLE
Add a warning to use the mysql backend for nextcloud

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -71,6 +71,10 @@ Installation
 
 Now point your browser to your uberspace URL and follow the instructions.
 
+.. warning:: We strongly recommend you to use the MySQL backend for netxtcloud. Do not use the SQLite backend for production. It gives you a better performance and reduces disk load on the host you share.
+
+::
+
 You will need to enter the following information:
 
   * Administrator username and password: Insert the credentials you want to use for the admin user

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -73,8 +73,6 @@ Now point your browser to your uberspace URL and follow the instructions.
 
 .. warning:: We strongly recommend you to use the MySQL backend for netxtcloud. Do not use the SQLite backend for production. It gives you a better performance and reduces disk load on the host you share.
 
-::
-
 You will need to enter the following information:
 
   * Administrator username and password: Insert the credentials you want to use for the admin user


### PR DESCRIPTION
For installations it is strongly recommended to use the mysql backend because the sqlite one isn't performing very well.