### PR TITLE
fix nodejs tags

### DIFF
--- a/source/guide_ethercalc.rst
+++ b/source/guide_ethercalc.rst
@@ -3,7 +3,7 @@
 .. author:: Achim | pxlfrk <hallo@pxlfrk.de>
 
 .. tag:: spreadsheet
-.. tag:: lang-node-js
+.. tag:: lang-nodejs
 .. tag:: web
 .. tag:: collaborative-editing
 

--- a/source/guide_wekan.rst
+++ b/source/guide_wekan.rst
@@ -1,7 +1,7 @@
 .. highlight:: console
 
 .. author:: Andrej <https://github.com/schoeke>
-.. tag:: lang-node
+.. tag:: lang-nodejs
 .. tag:: project-management
 .. tag:: web
 


### PR DESCRIPTION
Some tag variants have been renamed in favor of the [popular software link for nodejs in the manual](https://manual.uberspace.de/lang-nodejs/#popular-software).