### PR TITLE
Fix ejabberd installation path and compilation command

### DIFF
--- a/source/guide_ejabberd.rst
+++ b/source/guide_ejabberd.rst
@@ -54,7 +54,8 @@ Run ``./configure --help`` to see all options.
   [isabell@stardust ~]$ tar xf 20.04.tar.gz
   [isabell@stardust ~]$ cd ejabberd-20.04/
   [isabell@stardust ejabberd-20.04]$ ./autogen.sh
-  [isabell@stardust ejabberd-20.04]$ ./configure --enable-user=$USER --prefix=$HOME/opt/ejabberd --enable-mysql --enable-new-sql-schema
+  [isabell@stardust ejabberd-20.04]$ ./configure --enable-user=$USER --prefix=$HOME --enable-mysql --enable-new-sql-schema
+  [isabell@stardust ejabberd-20.04]$ make
   [isabell@stardust ejabberd-20.04]$ make install
 
 The files will be installed to the following locations:


### PR DESCRIPTION
Align the installation path in the ejabberd guide with the description. Fix the compilation to run “make” before “make install” which is required for existing installations.