### PR TITLE
[ghost] Updated section 'Prerequisites'

### DIFF
--- a/source/guide_ghost.rst
+++ b/source/guide_ghost.rst
@@ -37,13 +37,13 @@ The concept of the Ghost platform was first floated publicly in November 2012 in
 Prerequisites
 =============
 
-We're using :manual:`Node.js <lang-nodejs>` in the stable version 10:
+We're using :manual:`Node.js <lang-nodejs>` in the stable version 12:
 
 ::
 
- [isabell@stardust ~]$ uberspace tools version use node 10
- Using 'Node.js' version: '10'
- Selected node version 10
+ [isabell@stardust ~]$ uberspace tools version use node 12
+ Using 'Node.js' version: '12'
+ Selected node version 12
  The new configuration is adapted immediately. Patch updates will be applied automatically.
  [eliza@dolittle ~]$
 


### PR DESCRIPTION
We should update the mentioned Node.js version from v10 to v12, because v12 is the new Uberspace default (see https://manual.uberspace.de/lang-nodejs/) and it is also the recommended version of Ghost.org (see https://ghost.org/docs/faq/node-versions/).