### PR TITLE
[wsgidav] Fixed host ip address

### DIFF
--- a/source/guide_wsgidav.rst
+++ b/source/guide_wsgidav.rst
@@ -101,6 +101,12 @@ Save the file here:
 Configure web server
 ====================
 
+To make the web server available as a web backend you have to explicitly set the host ip address in the configuration file ``~/etc/wsgidav.yaml``.
+
+::
+
+host: 0.0.0.0
+
 .. note::
 
     wsgidav is running on port 8080.
@@ -130,6 +136,6 @@ Now go to ``https://<username>.uber.space`` (would be ``https://isabell.uber.spa
 
 ----
 
-Tested with wsgidav 3.0.0, Uberspace 7.3.4.2
+Tested with wsgidav 3.1.0, Uberspace 7.8.1.0
 
 .. author_list::


### PR DESCRIPTION
Explicitly set host ip address to 0.0.0.0

For Wsgidav to be usable as a web backend it needs to listen on 0.0.0.0:8080 and not localhost:8080, which is default.

Tested with wsgidav 3.1.0, Uberspace 7.8.1.0