### PR TITLE
Add python crypto installation error solution note

### DIFF
--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -82,6 +82,7 @@ We will install synapse using pip, which makes it quite easy:
 .. note:: If you get a compilation error due to missing rust components in the cryptography library for python it may help to run:
 
 .. code-block:: console
+
   [isabell@stardust ~]$ pip3.6 install --user setuptools_rust
   [isabell@stardust ~]$ python3 -m pip install --upgrade  --user pip
   [isabell@stardust ~]$ 

--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -78,6 +78,14 @@ We will install synapse using pip, which makes it quite easy:
   [isabell@stardust ~]$
 
 
+
+.. note:: If you get a compilation error due to missing rust components in the cryptography library for python it may help to run:
+
+.. code-block:: console
+  [isabell@stardust ~]$ pip3.6 install --user setuptools_rust
+  [isabell@stardust ~]$ python3 -m pip install --upgrade  --user pip
+  [isabell@stardust ~]$ 
+
 Configuration
 =============
 


### PR DESCRIPTION
Add note to update pip and install setuptools_rust in order to fix cryptography install error.