### PR TITLE
Remove the App "document server community edition" (some kind of OnlyOffice) due to major flaws (data loss!)

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -293,25 +293,6 @@ To adapt some database configs to make Nextcloud run smoother execute these comm
 Apps
 ----
 
-Onlyoffice (Community Edition)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-To edit text and spreadsheet documents, you need to install and enable these apps from the admin interface:
-
-* Community Document Server (a light version of the Onlyoffice server)
-* Onlyoffice (the connector to the Onlyoffice server)
-
-Both apps can be installed optional during the main install, but the huge document server may fail. Then install it manually from the shell:
-
-.. code-block:: console
-
-  [isabell@stardust html]$ cd apps
-  [isabell@stardust apps]$ curl -L https://github.com/nextcloud/documentserver_community/releases/latest/download/documentserver_community.tar.gz | tar -xvzf -
-  [isabell@stardust apps]$
-
-Reload the admin panel and enable the Community Document Server.
-A click on a text/spreadsheet document should now start the Onlyoffice Editor.
-
 Nextcloud Talk
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Remove the App "document server community edition" (some kind of OnlyOffice), because of major flaws, see "Edits and changes made in Onlyoffice are not synced into Nextcloud #100" https://github.com/nextcloud/documentserver_community/issues/100