### PR TITLE
Remove trailing "s" in supervisord setup

### DIFF
--- a/source/guide_writefreely.rst
+++ b/source/guide_writefreely.rst
@@ -161,8 +161,8 @@ Create ``~/etc/services.d/writefreely.ini`` with the following content:
 .. code-block:: ini
 
   [program:writefreely]
-  directory=%(ENV_HOME)s/writefreely/
-  command=%(ENV_HOME)s/writefreely/writefreely
+  directory=%(ENV_HOME)/writefreely/
+  command=%(ENV_HOME)/writefreely/writefreely
   autostart=yes
   autorestart=yes
 


### PR DESCRIPTION
I bet that's an typo, is it @thisven (original author of this file)?