### PR TITLE
[nextcloud] remove nocontent.html

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -130,6 +130,7 @@ Downloading
 .. code-block:: console
 
  [isabell@stardust ~]$ cd html
+ [isabell@stardust html]$ rm nocontent.html
  [isabell@stardust html]$ curl https://download.nextcloud.com/server/releases/latest.tar.bz2 | tar -xjf - --strip-components=1
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed


### PR DESCRIPTION
simple remove command for `nocontent.html`, otherwise updates wont work, could be made more sophisticated in the future

fix #996 