### PR TITLE
Create User CLI usage for Gitea changed

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -261,7 +261,7 @@ Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ ~/gitea/gitea admin create-user --username adminuser --password ${ADMPWD} --email ${USER}@uber.space --admin
+  [isabell@stardust ~]$ ~/gitea/gitea admin user create --username adminuser --password ${ADMPWD} --email ${USER}@uber.space --admin
   [isabell@stardust ~]$
   ...
   New user 'adminuser' has been successfully created!


### PR DESCRIPTION
According to https://docs.gitea.io/en-us/command-line/#admin it's `user create` instead of `create-user` now.