### PR TITLE
feat: update umami guide how to limit nextjs ram

### DIFF
--- a/source/guide_umami.rst
+++ b/source/guide_umami.rst
@@ -86,6 +86,8 @@ Now you can create the production build:
 
  [isabell@stardust umami]$ npm run build
  [isabell@stardust umami]$
+ 
+.. warning:: In newer versions, sometimes the build process fails without any errors in the `next build` stage. This is due to Uberspace killing the process for needing to much memory. If this happens, you will not be able to start the app – it will say `Error: Could not find a production build in the '/home/isabell/umami/.next [...]' directory. Try running the build process via `NODE_OPTIONS=--max_old_space_size=512 npx next build --debug` to limit the RAM usage and build the app successfully.
 
 Setup daemon
 ------------


### PR DESCRIPTION
* add a warning regarding the `next build` process ram usage, which will make it fail occasionally