### PR TITLE
[Synapse] Add configuration of public_baseurl

### DIFF
--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -106,6 +106,12 @@ Generate a config file ``~/synapse/homeserver.yaml`` and replace my.domain.name 
     --report-stats=[yes|no]
   [isabell@stardust ~]$
 
+Replace the ``public_baseurl`` in the config file ``~/synapse/homeserver.yaml`` with the url of your Synapse_.
+
+.. code-block:: yaml
+
+  public_baseurl: https://my.domain.name/
+
 Set the Synapse_ to listen for federation and clients on the correct localhost without encryption in the config file ``~/synapse/homeserver.yaml``. To do this, locate the ``listeners:`` section and modify the entry with ``port: 8008``:
 
 .. code-block:: yaml


### PR DESCRIPTION
public_baseurl needs to be configured in order for the Synapse to be discoverable by clients.

Closes #1066