### PR TITLE
Notice the memory limit in PHP.ini

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -103,6 +103,12 @@ Nextcloud `recommends 512 MB <https://docs.nextcloud.com/server/latest/admin_man
 .. code-block:: ini
 
  memory_limit=512M
+ 
+If you still see an error in the web UI, edit ``~/etc/php.d/php.ini`` with the following content:
+
+.. code-block:: ini
+
+ memory_limit=512M
 
 Output Buffering
 ^^^^^^^^^^^^^^^^

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -104,11 +104,6 @@ Nextcloud `recommends 512 MB <https://docs.nextcloud.com/server/latest/admin_man
 
  memory_limit=512M
  
-If you still see an error in the web UI, edit ``~/etc/php.d/php.ini`` with the following content:
-
-.. code-block:: ini
-
- memory_limit=512M
 
 Output Buffering
 ^^^^^^^^^^^^^^^^
@@ -433,6 +428,15 @@ If files are missing like if you move files or restore backups on the machine an
  [isabell@stardust html]$ php occ files:scan --all
  [isabell@stardust html]$ php occ files:scan-app-data
  [isabell@stardust html]$
+ 
+memory limit after migration from U6
+------------------------------------
+
+If you still see an error in the web UI, edit ``~/etc/php.d/php.ini`` with the following content:
+
+.. code-block:: ini
+
+ memory_limit=512M
 
 storage capacity problems
 -------------------------


### PR DESCRIPTION
As I ran to this issue today, I want to see it documented. I'm open for additional wording suggestions.
My setup migrated from U6 to U7. Formerly, I only had a php.ini with the content of Output Buffering and Memory Limit to be able to run Nextcloud.

The instructions here made many errors go away.
I only ran into some troubles with well known URLs but could resolve them. Do we want to document them here, too?
(Basically redirecting to index.php well-known URLs)