### PR TITLE
Update guide_wekan.rst

### DIFF
--- a/source/guide_wekan.rst
+++ b/source/guide_wekan.rst
@@ -178,7 +178,7 @@ To update, simply download the newest version from the `latest release`_ website
 
 .. note:: Check the update feed_ regularly to stay informed about the newest version. Wekan is updated often.
 
-.. _wekan: https://wekan.org/
+.. _wekan: https://wekan.github.io/
 .. _MIT License: https://github.com/wekan/wekan/blob/master/LICENSE
 .. _Wekan Wiki: https://github.com/wekan/wekan/wiki
 .. _Github: https://github.com/wekan/wekan


### PR DESCRIPTION
Fixed the old project URL (wekan.org) because it's offline.

The whole guide would still require an overall update, as the linked [release](https://releases.wekan.team/wekan-4.43.zip) is already non-existent.

Unfortunately, I don't have time for that right now. Maybe someone else could look into it. The project is still actively developed (see [changelog](https://github.com/wekan/wekan/blob/master/CHANGELOG.md)).