### PR TITLE
[jenkins] guide is broken

### DIFF
--- a/source/guide_jenkins.rst
+++ b/source/guide_jenkins.rst
@@ -18,6 +18,12 @@
 Jenkins
 ########
 
+.. error::
+
+  This guide seems to be **broken**. We would be happy if you want to work on
+  a solution and create a Pull Request. See also the related issue:
+  https://github.com/Uberspace/lab/issues/1098
+
 .. tag_list::
 
 Jenkins_ is an open source automation server written in Java. Jenkins helps to automate the non-human part of the software development process, with continuous integration and facilitating technical aspects of continuous delivery. It is a server-based system that runs in servlet containers such as Apache Tomcat. It supports version control tools, including AccuRev, CVS, Subversion, Git, Mercurial, Perforce, TD/OMS, ClearCase and RTC, and can execute Apache Ant, Apache Maven and sbt based projects as well as arbitrary shell scripts and Windows batch commands. The creator of Jenkins is Kohsuke Kawaguchi. Released under the MIT License, Jenkins is free software.


### PR DESCRIPTION
The guide for Jenkins does not work anymore. Jenkins does not run with Java version 16. We added a banner to the guide to signal the broken state.

https://github.com/Uberspace/lab/issues/1098