### PR TITLE
[Mailman 3] make Django Cluster use 4 worker processes

### DIFF
--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -302,6 +302,16 @@ After the REST backend has been configured, we need to configure the Django fron
     ('text/x-scss', '/home/isabell/bin/dart-sass/sass {infile} {outfile}'),
     ('text/x-sass', '/home/isabell/bin/dart-sass/sass {infile} {outfile}'),
  )
+ 
+ [...]
+ 
+ Q_CLUSTER = {
+    'timeout': 100,
+    'retry': 200,
+    'save_limit': 100,
+    'orm': 'default',
+    'workers': 4,
+}
 
  # Comment the following lines out to test sending mail
  #if DEBUG == True:

--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -306,12 +306,12 @@ After the REST backend has been configured, we need to configure the Django fron
  [...]
  
  Q_CLUSTER = {
-    'timeout': 100,
-    'retry': 200,
-    'save_limit': 100,
-    'orm': 'default',
-    'workers': 4,
-}
+     'timeout': 100,
+     'retry': 200,
+     'save_limit': 100,
+     'orm': 'default',
+     'workers': 4,
+ }
 
  # Comment the following lines out to test sending mail
  #if DEBUG == True:


### PR DESCRIPTION
Each worker process consumes 60MB memory. The default number of worker is equal to CPU count (ie. like 20, which uses way too much memory!!)

The other variables use the default values.