### PR TITLE
use python3.6 -m pip instead of pip3.6

### DIFF
--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -272,7 +272,7 @@ Watch MatrixRSS_ to be notified of upgrades and if there is a update, use pip to
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ pip3.6 install --user -U matrix-synapse
+  [isabell@stardust ~]$ python3.6 -m pip install --user -U matrix-synapse
   [isabell@stardust ~]$
 
 Automate the update process with a bash script called `~/bin/synapse-update` containing:
@@ -282,7 +282,7 @@ Automate the update process with a bash script called `~/bin/synapse-update` con
   #!/bin/bash
   # update synapse and restart the service
 
-  pip3.6 install --user -U matrix-synapse
+  python3.6 -m pip install --user -U matrix-synapse
   supervisorctl restart synapse
 
 Make it executeable:


### PR DESCRIPTION
I got this warning:

WARNING: pip is being invoked by an old script wrapper. This will fail in a future version of pip.
Please see https://github.com/pypa/pip/issues/5599 for advice on fixing the underlying issue.
To avoid this problem you can invoke Python with '-m pip' instead of running pip directly.