### PR TITLE
[Nextcloud] 📝 use PHP 8.0 as recommended

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -40,12 +40,12 @@ Nextcloud was initially released in 2016 as a fork of ownCloud_ and is maintaine
 Prerequisites
 =============
 
-We are using :manual:`PHP <lang-php>` in the version 7.4:
+Use the recommended :manual:`PHP <lang-php>` version as listed in the `system requirements`_:
 
 .. code-block:: console
 
- [isabell@stardust ~]$ uberspace tools version use php 7.4
- Selected PHP version 7.4
+ [isabell@stardust ~]$ uberspace tools version use php 8.0
+ Selected PHP version 8.0
  The new configuration is adapted immediately. Patch updates will be applied automatically.
  [isabell@stardust ~]$
 
@@ -484,6 +484,7 @@ To solve the issue, apply the ``apc.enable_cli=1`` step above to your installati
 
 .. _ownCloud: https://owncloud.org
 .. _Nextcloud: https://nextcloud.com
+.. _`system requirements`: https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html
 .. _`Nextcloud admin manual for email`: https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/email_configuration.html#email
 .. _`Nextcloud App Store`: https://apps.nextcloud.com
 .. _SELinux labels: https://wiki.gentoo.org/wiki/SELinux/Labels#Introduction


### PR DESCRIPTION
Changes:
- use PHP 8.0

[👀 deploy preview](https://deploy-preview-1152--uberlab.netlify.app/guide_nextcloud.html)

- [x] guide is working with a new asteroid 🪨
- [X] run `make clean html` without relevant warnings
- [X] run `make spelling` without relevant warnings

closes #1114