### PR TITLE
Update guide_mailman-3.rst

### DIFF
--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -160,6 +160,7 @@ At first, we need to configure the REST interface of the core component. Create 
  smtp_host: stardust.uberspace.de
  lmtp_port: 8024
  smtp_port: 587
+ smtp_secure_mode: starttls
  smtp_user: forwarder@isabell.uber.space
  smtp_pass: mailpassword
 


### PR DESCRIPTION
Since today 10:00 UTC, my mailman failed on sending mails via SMTP with the following error:
``delivery to someone@example.com failed with code 444, SMTP AUTH extension not supported by server.``

I fixed it with this change in ``mailman.cfg``.