### PR TITLE
[Starship] Update install method, bugfixing, copy-editing

### DIFF
--- a/source/guide_starship.rst
+++ b/source/guide_starship.rst
@@ -1,6 +1,7 @@
 .. highlight:: console
 
-.. author:: Michi <https://github.com/michi-zuri/>
+.. author:: Michi <https://github.com/michi-zuri>
+.. author:: Mike <https://github.com/fooforge>
 
 .. tag:: console
 .. tag:: rust
@@ -47,22 +48,37 @@ work out of the box.
 
 Installation
 ============
+
+To install the prebuilt binary you need to curl the install script from the project's
+website. Once installed, you can execute Starship_ to update your current shell's prompt.
+
 .. code-block:: console
 
- [isabell@stardust ~]$ cargo install starship
+ [isabell@stardust ~]$ sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --bin-dir ~/bin --yes
+ [...]
+ [isabell@stardust ~]$ eval "$(~/bin/starship init bash)"
+ isabell on stardust in ~
+
+Piping install scripts into a shell can be dangerous! Less so on a virtual host with
+non-elevated user rights, but still. To review the install script before any action is being taken
+you can run the above command like below. This will open your default editor. If anything looks
+suspicious, to abort the installation you would need to remove the file's content and save your changes.
+
+.. code-block:: console
+
+[isabell@stardust ~]$ curl -fsSL https://starship.rs/install.sh | vipe | sh -s -- --bin-dir ~/bin --yes
  [...]
  [isabell@stardust ~]$ eval "$(starship init bash)"
  isabell on stardust in ~
- >
 
-To make the prompt permanent, add one line to your .bashrc:
+To make the prompt permanent, add a newline and the below eval statement to your ``.bashrc``:
 
 .. code-block:: console
 
  isabell on stardust in ~
  > echo -e '\n' >> .bashrc
  isabell on stardust in ~
- > echo 'eval "$(starship init bash)"' >> .bashrc
+ > echo 'eval "$(~/bin/starship init bash)"' >> .bashrc
  isabell on stardust in ~
  >
 
@@ -70,20 +86,22 @@ That's it, you have successfully installed Starship_ to your Uberspace console:
 
 .. code-block:: console
 
- [isabell@localhost ~]$ ssh <username>@<username>.uber.space
+ [isabell@localhost ~]$ ssh isabell@stardust
  Welcome to Uberspace7!
  [...]
  isabell on stardust in ~
- >
 
+To start customizing your prompt, have a look at `Starship's Presets`_. The configuration file lives
+in ``~/.config/starship.toml``.
 
 .. _Starship: https://starship.rs/
+.. _Starship's Presets: https://starship.rs/presets/#presets
 .. _`Nerd Font`: https://www.nerdfonts.com/
 .. _NerdFonts: https://www.nerdfonts.com/font-downloads
 .. _`Windows 10`: https://support.microsoft.com/en-us/help/314960/how-to-install-or-remove-a-font-in-windows
 .. _macOS: https://support.apple.com/en-us/HT201749
 .. _blink.sh: https://blink.sh/
 
-Tested with Starship v0.44.0 and Uberspace version 7.7.7.0
+Tested with Starship v1.2.1 and Uberspace version 7.12.
 
 .. author_list::

--- a/source/guide_starship.rst
+++ b/source/guide_starship.rst
@@ -71,7 +71,7 @@ suspicious, to abort the installation you would need to remove the file's conten
  [isabell@stardust ~]$ eval "$(starship init bash)"
  isabell on stardust in ~
 
-To make the prompt permanent, add a newline and the below eval statement to your ``.bashrc``:
+To make the prompt permanent, add a newline and the below eval statement to your ``~/.bashrc``:
 
 .. code-block:: console
 
@@ -91,11 +91,11 @@ That's it, you have successfully installed Starship_ to your Uberspace console:
  [...]
  isabell on stardust in ~
 
-To start customizing your prompt, have a look at `Starship's Presets`_. The configuration file lives
+To start customizing your prompt, have a look at `Starship's Presets`_'. The configuration file lives
 in ``~/.config/starship.toml``.
 
 .. _Starship: https://starship.rs/
-.. _Starship's Presets: https://starship.rs/presets/#presets
+.. _`Starship's Presets`: https://starship.rs/presets/#presets
 .. _`Nerd Font`: https://www.nerdfonts.com/
 .. _NerdFonts: https://www.nerdfonts.com/font-downloads
 .. _`Windows 10`: https://support.microsoft.com/en-us/help/314960/how-to-install-or-remove-a-font-in-windows


### PR DESCRIPTION
Signed up for Uberspace today, explored things a bit and realized that the documented way to install [Starship](https://starship.rs/) isn't working anymore. Taken this as an opportunity to contribute the below fixes:

### `cargo` install method => curl | sh

The installation via cargo currently fails with the following errors:

```
Compiling starship v1.2.1
error[E0658]: use of unstable library feature 'command_access'
   --> /home/fooforge/.cargo/registry/src/github.com-1ecc6299db9ec823/starship-1.2.1/src/utils.rs:392:56
    |
392 |             log::info!("Unable to run {:?}, {:?}", cmd.get_program(), error);
    |                                                        ^^^^^^^^^^^
    |
    = note: see issue #44434 <https://github.com/rust-lang/rust/issues/44434> for more information

error[E0658]: use of unstable library feature 'command_access'
   --> /home/fooforge/.cargo/registry/src/github.com-1ecc6299db9ec823/starship-1.2.1/src/utils.rs:436:65
    |
436 |             log::warn!("Executing command {:?} timed out.", cmd.get_program());
    |                                                                 ^^^^^^^^^^^
    |
    = note: see issue #44434 <https://github.com/rust-lang/rust/issues/44434> for more information

error[E0658]: use of unstable library feature 'command_access'
   --> /home/fooforge/.cargo/registry/src/github.com-1ecc6299db9ec823/starship-1.2.1/src/utils.rs:443:21
    |
443 |                 cmd.get_program(),
    |                     ^^^^^^^^^^^
    |
    = note: see issue #44434 <https://github.com/rust-lang/rust/issues/44434> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `starship` due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `starship v1.2.1`, intermediate artifacts can be found at `/tmp/cargo-installN2CzAt`

Caused by:
  build failed
```

The linked issue https://github.com/rust-lang/rust/issues/44434 did not yield any immediate steps to fix the issue. And, by the looks of it, the installation via `cargo` also isn't documented on the project's website.

I have therefore changed the guide to use the steps lined out on https://starship.rs/guide/#🚀-installation instead. Given the dangerousness of piping curl to sh I have also added a blurb on how to review the install script before it gets executed.

### Fix for loading Starship upon login

The portion of the guide to load Starship upon login by adding a stanza to my `.bashrc` also didn't work for me on my fresh install, and resulted in the following error message:

```
-bash: starship: command not found
[fooforge@ara ~]$
```

This is due to `.bashrc` being sourced in `.bash_profile` before the PATH variable gets set. To rectify this, I have simply switched the `eval` statement to use an absolute path instead.

---

These two larger changes aside, I have made some small copy-editing changes and added a short section on what to do next with Starship. Given the updates, I have also added my name to the author's list. 😃

I haven't had the chance to run the linter yet, but will revisit once this PR exists.

@michi-zuri As the original author, I'd appreciate if you could take a 👀 at my proposed changes. Thanks!