### PR TITLE
Update guide_nextcloud.rst

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -81,7 +81,7 @@ OPcache caches script bytecode in shared memory, so scripts need not to be loade
 
  opcache.enable=1
  opcache.enable_cli=1
- opcache.interned_strings_buffer=8
+ opcache.interned_strings_buffer=16
  opcache.max_accelerated_files=10000
  opcache.memory_consumption=128
  opcache.save_comments=1


### PR DESCRIPTION
After finalizing my installation, I got aware of a system configuration notification:
Einstellungen > Verwaltung > Übersicht:
Es gibt einige Warnungen bei Deiner Systemkonfiguration.
The PHP OPcache module is not properly configured:
The OPcache interned strings buffer is nearly full. To assure that repeating strings can be effectively cached, it is recommended to apply opcache.interned_strings_buffer to your PHP configuration with a value higher than 8.

Having read https://www.techgrube.de/tutorials/php-seiten-wie-wordpress-mit-opcache-beschleunigen I raised that value to 16, now Nextcloud seems to be satisfied and reports no errors anymore. You may want to verify if this is useful to others too.