### PR TITLE
[kimai] remove obsolte PHP prerequisites instructions

### DIFF
--- a/source/guide_kimai.rst
+++ b/source/guide_kimai.rst
@@ -39,17 +39,6 @@ Kimai is released under the `MIT License`_. All relevant information can be foun
 Prerequisites
 =============
 
-We’re using :manual:`PHP <lang-php>` in the stable version 7.2. Since new Uberspaces are currently setup with PHP 7.1 by default you need to set this version manually:
-
-::
-
- [isabell@stardust ~]$ uberspace tools version use php 7.2
- Selected PHP version 7.2
- The new configuration is adapted immediately. Patch updates will be applied automatically.
- [isabell@stardust ~]$
-
-.. include:: includes/my-print-defaults.rst
-
 Your website domain needs to be set up:
 
 .. include:: includes/web-domain-list.rst


### PR DESCRIPTION
Uberspace 7.12 uses PHP 7.4 per default and Kimai has dropped PHP 7.2
since version 1.15.

Relevant kimai blog post:
https://www.kimai.org/blog/2021/php8-support-php72-dropped/