### PR TITLE
[Gitea] rework guide

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -250,7 +250,10 @@ Create a file ``~/etc/services.d/gitea.ini`` for the service ...
 .. code-block:: ini
 
   [program:gitea]
-  command=%(ENV_HOME)s/gitea/gitea web
+  directory=%(ENV_HOME)s/gitea
+  command=gitea web
+  startsecs=30
+  autorestart=yes
 
 .. include:: includes/supervisord.rst
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -38,7 +38,10 @@ We need a database:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ mysql -e "CREATE DATABASE ${USER}_gitea"
+  [isabell@stardust ~]$ mysql --verbose --execute="CREATE DATABASE ${USER}_gitea"
+  --------------
+  CREATE DATABASE isabell_gitea
+  --------------
   [isabell@stardust ~]$
 
 We can use the uberspace or your own domain:
@@ -56,10 +59,10 @@ Check current version of Gitea at releases_ page.
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ VERSION=1.14.4
+  [isabell@stardust ~]$ VERSION=1.16.3
   [isabell@stardust ~]$ mkdir -p ~/gitea
   [isabell@stardust ~]$ wget -O ~/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64
-  --2020-06-01 21:00:31--  https://github.com/go-gitea/gitea/releases/download/v1.14.4/gitea-1.14.4-linux-amd64
+  --2020-06-01 21:00:31--  https://github.com/go-gitea/gitea/releases/download/vX.Y.Z/gitea-X.Y.Z-linux-amd64
   Resolving github.com (github.com)... 140.82.118.3
   Connecting to github.com (github.com)|140.82.118.3|:443... connected.
   HTTP request sent, awaiting response... 302 Found
@@ -114,7 +117,8 @@ If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ chmod u+x ~/gitea/gitea
+  [isabell@stardust ~]$ chmod u+x --verbose ~/gitea/gitea
+  mode of '/home/isabell/gitea/gitea' changed from 0664 (rw-rw-r--) to 0764 (rwxrw-r--)
   [isabell@stardust ~]$
 
 
@@ -142,6 +146,7 @@ Create a custom directory.
 The minimum set of ``~/gitea/custom/conf/app.ini`` is:
 
 .. code-block:: ini
+  :emphasize-lines: 3
 
   [server]
   HTTP_PORT = 9000
@@ -162,6 +167,7 @@ For more information about the possibilities and configuration options see the G
 .. warning:: Replace ``isabell`` with your username, fill the database password ``PASSWD =`` with yours and enter the generated random into ``SECRET_KEY =``.
 
 .. code-block:: ini
+  :emphasize-lines: 2,7,14-16,23,31,36
 
   APP_NAME = Gitea
   RUN_USER = isabell
@@ -366,6 +372,6 @@ To update do:
 
 ----
 
-Tested with Gitea 1.14.4, Uberspace 7.6.2.0
+Tested with Gitea 1.16.3, Uberspace 7.6.2.0
 
 .. author_list::

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -299,9 +299,11 @@ If we're using the same ssh key for auth to uberspace and Gitea, we need to modi
 
   command="if [ -t 0 ]; then bash; elif [[ ${SSH_ORIGINAL_COMMAND} =~ ^(scp|rsync|mysqldump).* ]]; then eval ${SSH_ORIGINAL_COMMAND}; else /home/isabell/gitea/gitea serv key-1 --config='/home/isabell/gitea/custom/conf/app.ini'; fi",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ssh-...
 
-.. note:: Be careful to keep the key number ``key-X``, keep your key ``ssh-...`` and change the username ``isabell`` to yours.
+.. warning::
+  * Be careful to keep the key number ``key-X``, keep your key ``ssh-...`` and change the username ``isabell`` to yours.
+  * Take care that there is no second line propagating the same ssh key.
 
-.. note:: You can still use the Uberspace dashboard_ to add ssh keys.
+.. note:: You can still use the Uberspace dashboard_ to add other ssh keys for running default ssh sessions.
 
 To interact with Gitea at our local machine like ``git clone isabell@isabell.uber.space:giteauser/somerepo.git`` we configure the ``/home/localuser/.ssh/config`` file for our local machine with the git ssh key.
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -263,8 +263,6 @@ Uberspace web backend
 
 .. include:: includes/web-backend.rst
 
-.. note:: If we run the service under a domain subfolder aka prefix, you need to append the above command like ``uberspace web backend set exampe.net/subfolder --http --port 9000 --remove-prefix``.
-
 Done. We can point our browser to https://isabell.uber.space/.
 
 Installed files and folders are:

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -218,23 +218,25 @@ Above we locked the registration and the web installation feature, so this servi
 Gitea admin user
 ----------------
 
-We generate a safe password for the admin user. We use ``pwgen`` to create one set of 16 characters and write them into a variable to use it during the next two steps.
+Here we set our admin login credentials:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ ADMPWD=$(pwgen 16 1)
+
+  [isabell@stardust ~]$ ADMIN_USERNAME=AdminUsername
+  [isabell@stardust ~]$ ADMIN_PASSWORD='SuperSecretAdminPassword'
   [isabell@stardust ~]$
 
-Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us/command-line/#admin>`_. Gitea isn't allowing ``admin`` as name. We choose ``adminuser`` and the generated password from above. To ensure we remember the password beyond this installation session we store the password in a text file.
+Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us/command-line/#admin>`_. Gitea isn't allowing ``admin`` as name. To ensure we remember the password beyond this installation session we store the password in a text file.
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ ~/gitea/gitea admin user create --username adminuser --password ${ADMPWD} --email ${USER}@uber.space --admin
+  [isabell@stardust ~]$ ~/gitea/gitea admin user create --username ${ADMIN_USERNAME} --password ${ADMIN_PASSWORD} --email ${USER}@uber.space --admin
   [isabell@stardust ~]$
   ...
   New user 'adminuser' has been successfully created!
-  [isabell@stardust ~]$ echo "usr: adminuser" > ~/gitea/gitea-admin.txt
-  [isabell@stardust ~]$ echo "pwd: ${ADMPWD}" >> ~/gitea/gitea-admin.txt
+  [isabell@stardust ~]$ echo "usr: ${ADMIN_USERNAME}" > ~/gitea/gitea-admin.txt
+  [isabell@stardust ~]$ echo "pwd: ${ADMIN_PASSWORD}" >> ~/gitea/gitea-admin.txt
   [isabell@stardust ~]$
 
 Finishing installation

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -134,7 +134,7 @@ Before we write the configuration we need the MySQL database password from earli
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ pwgen 32 1
+  [isabell@stardust ~]$ ~/gitea/gitea generate secret SECRET_KEY
   SomeRandomCharactersyHxLQeGr976f
   [isabell@stardust ~]$
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -227,10 +227,10 @@ Set your admin login credentials:
 Finishing installation
 ======================
 
-Uberspace daemon for Gitea
----------------------------
+Service for Gitea
+-----------------
 
-Create a file ``~/etc/services.d/gitea.ini`` for the service ...
+To keep Gitea up and running in the background, you need to create a service that takes care for it. Create a config file ``~/etc/services.d/gitea.ini`` for the service:
 
 .. code-block:: ini
 
@@ -242,7 +242,7 @@ Create a file ``~/etc/services.d/gitea.ini`` for the service ...
 
 .. include:: includes/supervisord.rst
 
-.. note:: The status of gitea must be ``RUNNING``. If not, check the configuration file ``~/gitea/custom/conf/app.ini``.
+.. note:: The status of gitea must be ``RUNNING``. If its not check the log output at ``~/logs/supervisord.log`` and the configuration file ``~/gitea/custom/conf/app.ini``.
 
 Uberspace web backend
 ---------------------

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -52,10 +52,11 @@ We can use the uberspace or your own domain:
 Installation
 ============
 
-Download and verify
--------------------
 
-Check current version of Gitea at releases_ page.
+Download
+--------
+
+Check current version of Gitea at releases_ page:
 
 .. code-block:: console
 
@@ -70,22 +71,41 @@ Check current version of Gitea at releases_ page.
   2020-06-01 21:00:42 (8.11 MB/s) - ‘/home/isabell/gitea/gitea’ saved [83243800/83243800]
   [isabell@stardust ~]$
 
-Make the binary executable:
+
+Verifying (optional)
+--------------------
+
+Optionally you can verify the downloaded file using ``gpg``. To do so, download the pgp signature file and trust key
+and verify the binary:
+
+.. code-block:: console
+  :emphasize-lines: 7
+
+  [isabell@stardust ~]$ wget --output-document ~/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64.asc
+  […]
+  [isabell@stardust ~]$ curl --silent https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2 | gpg --import
+  […]
+  [isabell@stardust ~]$ gpg --verify ~/gitea/gitea.asc ~/gitea/gitea
+  gpg: Signature made Do 03 Mär 2022 15:48:38 CET using RSA key ID 9753F4B0
+  gpg: Good signature from "Teabot <teabot@gitea.io>"
+  gpg: WARNING: This key is not certified with a trusted signature!
+  gpg:          There is no indication that the signature belongs to the owner.
+  Primary key fingerprint: 7C9E 6815 2594 6888 62D6  2AF6 2D9A E806 EC15 92E2
+       Subkey fingerprint: CC64 B1DB 67AB BEEC AB24  B645 5FC3 4632 9753 F4B0
+
+If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot@gitea.io>"`` line. You need to ignore the ``WARNING`` here.
+
+
+Set permissions
+---------------
+
+Make the downloaded binary executable:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ chmod u+x ~/gitea/gitea
   [isabell@stardust ~]$
 
-| Optionally we can download the pgp signature file, trust key and verify our download with ``gpg``.
-| If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot@gitea.io>"`` line.
-| For this execute the following commands.
-
-.. code-block:: console
-
-  [isabell@stardust ~]$ wget -O ~/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64.asc
-  [isabell@stardust ~]$ curl --silent https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2 | gpg --import
-  [isabell@stardust ~]$ gpg --verify ~/gitea/gitea.asc ~/gitea/gitea
 
 Configuration
 =============

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -89,7 +89,7 @@ We use ``gpg`` to download the pgp key and verify our download.
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ gpg --keyserver keys.openpgp.org --recv 7C9E68152594688862D62AF62D9AE806EC1592E2
+  [isabell@stardust ~]$ curl --silent https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2 | gpg --import
   gpg: directory `/home/isabell/.gnupg' created
   gpg: new configuration file `/home/isabell/.gnupg/gpg.conf' created
   gpg: WARNING: options in `/home/isabell/.gnupg/gpg.conf' are not yet active during this run

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -1,4 +1,5 @@
 .. author:: Frank ℤisko <https://frank.zisko.io>
+.. author:: EV21 <uberlab@ev21.de>
 
 .. tag:: lang-go
 .. tag:: audience-developers

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -196,34 +196,6 @@ For more information about the possibilities and configuration options see the G
   MAILER_TYPE = sendmail
   FROM        = isabell@uber.space
 
-
-Gitea using external renderer (optional)
-----------------------------------------
-
-We can install an extra `external rendering <https://docs.gitea.io/en-us/external-renderers/>`_ extension AsciiDoc.
-
-.. code-block:: console
-
-  [isabell@stardust ~]$ gem install asciidoctor
-  Fetching asciidoctor-2.0.10.gem
-  WARNING:  You don't have /home/isabell/.gem/ruby/2.7.0/bin in your PATH,
-  	  gem executables will not run.
-  Successfully installed asciidoctor-2.0.10
-  1 gem installed
-  [isabell@stardust ~]$
-
-.. note:: Don't be irritated by the warning that the bin folder isn't in the path. Uberspace is taking care of it. You can check with ``[isabell@stardust ~]$ which asciidoctor``.
-
-Now we have to append the config file ``~/gitea/custom/conf/app.ini`` with:
-
-.. code-block:: ini
-
-  [markup.asciidoc]
-  ENABLED = true
-  FILE_EXTENSIONS = .adoc,.asciidoc
-  RENDER_COMMAND = "asciidoctor -e -a leveloffset=-1 --out-file=- -"
-  IS_INPUT_FILE = false
-
 Gitea initialization
 --------------------
 
@@ -264,45 +236,6 @@ Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us
   [isabell@stardust ~]$ echo "usr: adminuser" > ~/gitea/gitea-admin.txt
   [isabell@stardust ~]$ echo "pwd: ${ADMPWD}" >> ~/gitea/gitea-admin.txt
   [isabell@stardust ~]$
-
-Gitea ssh setup (optional)
---------------------------
-
-Gitea can manage the ssh keys. To use this feature we have to link the ssh folder into the gitea folder.
-
-.. code-block:: console
-
-  [isabell@stardust ~]$ ln -s ~/.ssh ~/gitea/.ssh
-  [isabell@stardust ~]$
-
-Now our Gitea users can add their ssh keys via the menu in the up right corner: ``->`` settings ``->`` tab: SSH/GPG Keys ``->`` Add Key. Gitea is automatically writing a ssh key command into the ``/home/isabell/.ssh/authorized_keys`` file. The key line is something similar like:
-
-.. code-block:: bash
-
-  command="/home/isabell/gitea/gitea --config='/home/isabell/gitea/custom/conf/app.ini' serv key-1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 AAAAC... youruser@yourhost
-
-If we're using the same ssh key for auth to uberspace and Gitea, we need to modify the server ``/home/isabell/.ssh/authorized_keys`` file.
-
-.. code-block:: bash
-
-  command="if [ -t 0 ]; then bash; elif [[ ${SSH_ORIGINAL_COMMAND} =~ ^(scp|rsync|mysqldump).* ]]; then eval ${SSH_ORIGINAL_COMMAND}; else /home/isabell/gitea/gitea serv key-1 --config='/home/isabell/gitea/custom/conf/app.ini'; fi",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ssh-...
-
-.. warning::
-  * Be careful to keep the key number ``key-X``, keep your key ``ssh-...`` and change the username ``isabell`` to yours.
-  * Take care that there is no second line propagating the same ssh key.
-
-.. note:: You can still use the Uberspace dashboard_ to add other ssh keys for running default ssh sessions.
-
-To interact with Gitea at our local machine like ``git clone isabell@isabell.uber.space:giteauser/somerepo.git`` we configure the ``/home/localuser/.ssh/config`` file for our local machine with the git ssh key.
-
-.. code-block::
-
-  Host isabell.uber.space
-      HostName isabell.uber.space
-      User isabell
-      IdentityFile ~/.ssh/id_your_git_key
-      IdentitiesOnly yes
-
 
 Finishing installation
 ======================
@@ -503,6 +436,74 @@ Run the updater
   Your Gitea is already up to date.
   You are running Gitea 1.16.3
   [isabell@stardust ~]$
+
+Additional configuration
+========================
+
+Gitea ssh setup (optional)
+--------------------------
+
+Gitea can manage the ssh keys. To use this feature we have to link the ssh folder into the gitea folder.
+
+.. code-block:: console
+
+  [isabell@stardust ~]$ ln -s ~/.ssh ~/gitea/.ssh
+  [isabell@stardust ~]$
+
+Now our Gitea users can add their ssh keys via the menu in the up right corner: ``->`` settings ``->`` tab: SSH/GPG Keys ``->`` Add Key. Gitea is automatically writing a ssh key command into the ``/home/isabell/.ssh/authorized_keys`` file. The key line is something similar like:
+
+.. code-block:: bash
+
+  command="/home/isabell/gitea/gitea --config='/home/isabell/gitea/custom/conf/app.ini' serv key-1",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-ed25519 AAAAC... youruser@yourhost
+
+If we're using the same ssh key for auth to uberspace and Gitea, we need to modify the server ``/home/isabell/.ssh/authorized_keys`` file.
+
+.. code-block:: bash
+
+  command="if [ -t 0 ]; then bash; elif [[ ${SSH_ORIGINAL_COMMAND} =~ ^(scp|rsync|mysqldump).* ]]; then eval ${SSH_ORIGINAL_COMMAND}; else /home/isabell/gitea/gitea serv key-1 --config='/home/isabell/gitea/custom/conf/app.ini'; fi",no-port-forwarding,no-X11-forwarding,no-agent-forwarding ssh-...
+
+.. warning::
+  * Be careful to keep the key number ``key-X``, keep your key ``ssh-...`` and change the username ``isabell`` to yours.
+  * Take care that there is no second line propagating the same ssh key.
+
+.. note:: You can still use the Uberspace dashboard_ to add other ssh keys for running default ssh sessions.
+
+To interact with Gitea at our local machine like ``git clone isabell@isabell.uber.space:giteauser/somerepo.git`` we configure the ``/home/localuser/.ssh/config`` file for our local machine with the git ssh key.
+
+.. code-block::
+
+  Host isabell.uber.space
+      HostName isabell.uber.space
+      User isabell
+      IdentityFile ~/.ssh/id_your_git_key
+      IdentitiesOnly yes
+
+Gitea using external renderer (optional)
+----------------------------------------
+
+We can install an extra `external rendering <https://docs.gitea.io/en-us/external-renderers/>`_ extension AsciiDoc.
+
+.. code-block:: console
+
+  [isabell@stardust ~]$ gem install asciidoctor
+  Fetching asciidoctor-2.0.10.gem
+  WARNING:  You don't have /home/isabell/.gem/ruby/2.7.0/bin in your PATH,
+  	  gem executables will not run.
+  Successfully installed asciidoctor-2.0.10
+  1 gem installed
+  [isabell@stardust ~]$
+
+.. note:: Don't be irritated by the warning that the bin folder isn't in the path. Uberspace is taking care of it. You can check with ``[isabell@stardust ~]$ which asciidoctor``.
+
+Now we have to append the config file ``~/gitea/custom/conf/app.ini`` with:
+
+.. code-block:: ini
+
+  [markup.asciidoc]
+  ENABLED = true
+  FILE_EXTENSIONS = .adoc,.asciidoc
+  RENDER_COMMAND = "asciidoctor -e -a leveloffset=-1 --out-file=- -"
+  IS_INPUT_FILE = false
 
 ..
   ##### Link section #####

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -220,7 +220,6 @@ Installed files and folders are:
 
 * ``~/gitea``
 * ``~/etc/services.d/gitea.ini``
-* ``~/.gem/ruby/2.7.0/*/asciidoctor*``, if AsciiDoctor is installed.
 
 Backup
 ======
@@ -445,6 +444,7 @@ Gitea using external renderer (optional)
 
 | Gitea supports custom file renderings (i.e. Jupyter notebooks, asciidoc, etc.) through external binaries to provide a preview.
 | In this case we install an `external rendering <https://docs.gitea.io/en-us/external-renderers/>`_ extension for AsciiDoc.
+| AsciiDoctors location will be here: ``~/.gem/ruby/2.7.0/*/asciidoctor*``
 
 .. code-block:: console
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -41,10 +41,7 @@ We need a database:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ mysql --verbose --execute="CREATE DATABASE ${USER}_gitea"
-  --------------
-  CREATE DATABASE isabell_gitea
-  --------------
+  [isabell@stardust ~]$ mysql --execute "CREATE DATABASE ${USER}_gitea"
   [isabell@stardust ~]$
 
 We can use the uberspace or your own domain:
@@ -120,8 +117,7 @@ If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ chmod u+x --verbose ~/gitea/gitea
-  mode of '/home/isabell/gitea/gitea' changed from 0664 (rw-rw-r--) to 0764 (rwxrw-r--)
+  [isabell@stardust ~]$ chmod u+x ~/gitea/gitea
   [isabell@stardust ~]$
 
 
@@ -411,8 +407,7 @@ Now make the script executable.
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ chmod u+x --verbose ~/bin/gitea-update
-  mode of '/home/isabell/bin/gitea-update' changed from 0664 (rw-rw-r--) to 0764 (rwxrw-r--)
+  [isabell@stardust ~]$ chmod u+x ~/bin/gitea-update
   [isabell@stardust ~]$
 
 Run the updater

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -238,6 +238,7 @@ To keep Gitea up and running in the background, you need to create a service tha
   directory=%(ENV_HOME)s/gitea
   command=gitea web
   startsecs=30
+  stopsignal=HUP
   autorestart=yes
 
 .. include:: includes/supervisord.rst
@@ -323,15 +324,13 @@ Create ``~/bin/gitea-update`` with the following content:
 
   function do_update_procedure
   {
+    $GITEA_LOCATION manager flush-queues
+    supervisorctl stop gitea
     wget --quiet --progress=bar:force --output-document $TMP_LOCATION/gitea "$DOWNLOAD_URL"
     verify_file
-    supervisorctl stop gitea
+    chmod u+x --verbose "$TMP_LOCATION/gitea"
     mv --verbose $TMP_LOCATION/gitea "$GITEA_LOCATION"
-    chmod u+x --verbose "$GITEA_LOCATION"
-    echo "Start gitea migration"
-    $GITEA_LOCATION migrate
     supervisorctl start gitea
-    sleep 5
     supervisorctl status gitea
   }
 
@@ -421,8 +420,22 @@ Run the updater
 .. code-block:: console
 
   [isabell@stardust ~]$ gitea-update
-  Your Gitea is already up to date.
-  You are running Gitea 1.16.3
+  There is a new version available.
+  Doing update from 1.16.3 to 1.16.4
+  Flushed
+  gitea: stopped
+  pub   4096R/EC1592E2 2018-06-24 [expires: 2022-06-24]
+        Key fingerprint = 7C9E 6815 2594 6888 62D6  2AF6 2D9A E806 EC15 92E2
+  uid                  Teabot <teabot@gitea.io>
+  sub   4096R/CBADB9A0 2018-06-24 [expires: 2022-06-24]
+  sub   4096R/9753F4B0 2018-06-24 [expires: 2022-06-24]
+
+  gpg: Signature made Mon Mar 14 23:02:56 2022 CET using RSA key ID 9753F4B0
+  gpg: Good signature from "Teabot <teabot@gitea.io>"
+  '/home/test42/tmp/gitea' -> '/home/test42/gitea/gitea'
+  mode of '/home/test42/gitea/gitea' changed from 0664 (rw-rw-r--) to 0764 (rwxrw-r--)
+  gitea: started
+  gitea                            RUNNING   pid 6789, uptime 0:00:31
   [isabell@stardust ~]$
 
 Additional configuration

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -135,14 +135,14 @@ Before we write the configuration we need the MySQL database password from earli
 .. code-block:: console
 
   [isabell@stardust ~]$ ~/gitea/gitea generate secret SECRET_KEY
-  SomeRandomCharactersyHxLQeGr976f
+  <RANDOM_64_CHARACTERS_FROM_GENERATOR>
   [isabell@stardust ~]$
 
 Create a custom directory.
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ mkdir -p ~/gitea/custom/conf/
+  [isabell@stardust ~]$ mkdir --parents ~/gitea/custom/conf/
   [isabell@stardust ~]$
 
 Create ``~/gitea/custom/conf/app.ini`` with the content of the following code block:
@@ -157,31 +157,25 @@ For more information about the possibilities and configuration options see the G
 .. warning:: Replace ``isabell`` with your username, fill the database password ``PASSWD =`` with yours and enter the generated random into ``SECRET_KEY =``.
 
 .. code-block:: ini
-  :emphasize-lines: 2,7,14-16,23,31,36
-
-  APP_NAME = Gitea
-  RUN_USER = isabell
-  RUN_MODE = prod ; Either "dev", "prod" or "test", default is "dev".
+  :emphasize-lines: 2,9-11,17,25,30
 
   [server]
-  HTTP_PORT            = 9000
   DOMAIN               = isabell.uber.space
   ROOT_URL             = https://%(DOMAIN)s
   OFFLINE_MODE         = true ; privacy option.
+  LFS_START_SERVER     = true ; Enables Git LFS support
 
   [database]
   DB_TYPE  = mysql
-  HOST     = 127.0.0.1:3306
   NAME     = isabell_gitea
   USER     = isabell
   PASSWD   = <MySQL_PASSWORD>
-  SSL_MODE = disable
 
   [security]
   INSTALL_LOCK        = true
   MIN_PASSWORD_LENGTH = 8
   PASSWORD_COMPLEXITY = lower
-  SECRET_KEY          = <RANDOM_32_CHARS>
+  SECRET_KEY          = <RANDOM_64_CHARACTERS_FROM_GENERATOR>
 
   [service]
   DISABLE_REGISTRATION       = true ; security option, only admins can create new users.
@@ -195,6 +189,9 @@ For more information about the possibilities and configuration options see the G
   ENABLED     = true
   MAILER_TYPE = sendmail
   FROM        = isabell@uber.space
+
+  [repository]
+  DEFAULT_BRANCH = main
 
 Gitea initialization
 --------------------
@@ -262,7 +259,7 @@ Create a file ``~/etc/services.d/gitea.ini`` for the service ...
 Uberspace web backend
 ---------------------
 
-.. note:: gitea is running on port 9000.
+.. note:: gitea is running on port 3000.
 
 .. include:: includes/web-backend.rst
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -145,20 +145,8 @@ Create a custom directory.
   [isabell@stardust ~]$ mkdir -p ~/gitea/custom/conf/
   [isabell@stardust ~]$
 
-The minimum set of ``~/gitea/custom/conf/app.ini`` is:
-
-.. code-block:: ini
-  :emphasize-lines: 3
-
-  [server]
-  HTTP_PORT = 9000
-  DOMAIN = isabell.uber.space
-  ROOT_URL = https://%(DOMAIN)s
-
-  [service]
-  DISABLE_REGISTRATION = true
-
-When using this, we have to finish the installation via gitea web service https://isabell.uber.space/install. This is exposed without any password request. We improve the configuration with some modifications, e.g.:
+Create ``~/gitea/custom/conf/app.ini`` with the content of the following code block:
+We improve the configuration with some modifications, e.g.:
 
 * Filling the database access data that we would otherwise enter in the web installation step. (``[database]`` section)
 * As security feature we lock the web installation and change the default password complexity to allow well to remember and secure passwords. (See `XKCD No. 936 <https://xkcd.com/936/>`_  and `Explained XKCD No. 936 <https://explainxkcd.com/wiki/index.php/936:_Password_Strength>`_ for the math behind it. 😉 ``[security]`` section)

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -208,6 +208,7 @@ Gitea admin user
 ----------------
 
 Here we set our admin login credentials:
+Gitea does not allow ``admin`` as name.
 
 .. code-block:: console
 
@@ -215,7 +216,7 @@ Here we set our admin login credentials:
   [isabell@stardust ~]$ ADMIN_PASSWORD='SuperSecretAdminPassword'
   [isabell@stardust ~]$
 
-Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us/command-line/#admin>`_. Gitea isn't allowing ``admin`` as name. To ensure we remember the password beyond this installation session we store the password in a text file.
+Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us/command-line/#admin>`_. To ensure we remember the password beyond this installation session we store the password in a text file.
 
 .. code-block:: console
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -473,7 +473,8 @@ To interact with Gitea at our local machine like ``git clone isabell@isabell.ube
 Gitea using external renderer (optional)
 ----------------------------------------
 
-We can install an extra `external rendering <https://docs.gitea.io/en-us/external-renderers/>`_ extension AsciiDoc.
+| Gitea supports custom file renderings (i.e. Jupyter notebooks, asciidoc, etc.) through external binaries to provide a preview.
+| In this case we install an `external rendering <https://docs.gitea.io/en-us/external-renderers/>`_ extension for AsciiDoc.
 
 .. code-block:: console
 

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -196,20 +196,12 @@ For more information about the possibilities and configuration options see the G
 Gitea initialization
 --------------------
 
-Above we locked the registration and the web installation feature, so this service will never be exposed in an insecure way to the internet. So we have to do the provided steps to create the database layout and generate security keys manually.
+Above we locked the registration and the web installation feature, so this service will never be exposed in an insecure way to the internet. We create the database layout by running the migrate command without running the server.
 
 .. code-block:: console
 
   [isabell@stardust ~]$ ~/gitea/gitea migrate
   ... a lot of console output about the database commands.
-  [isabell@stardust ~]$ ~/gitea/gitea generate secret INTERNAL_TOKEN
-  Some-Random-Characters-eyJhbUNIn6CJ9.eyJuYmYiOjE1OTEwNDAyNTB9.xYynv0JXwO-aqE5XEkGZE8mEeiQEOl-rU0JXpdPbLck
-  [isabell@stardust ~]$ ~/gitea/gitea generate secret SECRET_KEY
-  Some-Random-Characters-omddgYYpZTiMbrtBtgHU1f8ASXvS9Tlx6ETYiCwbJ
-  [isabell@stardust ~]$ ~/gitea/gitea generate secret JWT_SECRET
-  Some-Random-Characters-qRsvc0BtKZRmNvbo22a8
-  [isabell@stardust ~]$ ~/gitea/gitea generate secret LFS_JWT_SECRET
-  Some-Random-Characters-Lj7hGewx62tFGHZwRsVc
   [isabell@stardust ~]$
 
 Gitea admin user
@@ -218,7 +210,6 @@ Gitea admin user
 Here we set our admin login credentials:
 
 .. code-block:: console
-
 
   [isabell@stardust ~]$ ADMIN_USERNAME=AdminUsername
   [isabell@stardust ~]$ ADMIN_PASSWORD='SuperSecretAdminPassword'

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -277,18 +277,22 @@ Updates
 
 .. note:: Check the update feed_ or releases_ page regularly to stay informed about the newest version.
 
-To manually update do:
+
+Manual updating
+-----------------
 
 * Stop the application ``supervisorctl stop gitea``
-* Do the *download and verify* part from above.
+* Do the *Download* (and optionally *Verifying*) part from above.
 * Check if you have to modify the config file. (See documentation_ and the `file sample <https://github.com/go-gitea/gitea/blob/master/custom/conf/app.ini.sample>`_.)
-* Do the application migration: ``~/gitea/gitea migrate``
+* Do the database migration: ``~/gitea/gitea migrate``
 * Start the application ``supervisorctl start gitea``
 * Check if the application is running ``supervisorctl status gitea``
 
-You can also automate the update by using the ``gitea-update`` script.
 
-Create ``~/bin/gitea-update`` with the following content:
+Automated updating by custom script
+-----------------------------------
+
+You can also automate the update by using a custom script that automatically executes all the update steps. Create ``~/bin/gitea-update`` with the following content:
 
 .. code-block:: bash
 
@@ -412,8 +416,8 @@ Run the updater
 
   gpg: Signature made Mon Mar 14 23:02:56 2022 CET using RSA key ID 9753F4B0
   gpg: Good signature from "Teabot <teabot@gitea.io>"
-  '/home/test42/tmp/gitea' -> '/home/test42/gitea/gitea'
-  mode of '/home/test42/gitea/gitea' changed from 0664 (rw-rw-r--) to 0764 (rwxrw-r--)
+  '/home/isabell/tmp/gitea' -> '/home/isabell/gitea/gitea'
+  mode of '/home/isabell/gitea/gitea' changed from 0664 (rw-rw-r--) to 0764 (rwxrw-r--)
   gitea: started
   gitea                            RUNNING   pid 6789, uptime 0:00:31
   [isabell@stardust ~]$

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -60,66 +60,32 @@ Check current version of Gitea at releases_ page.
 .. code-block:: console
 
   [isabell@stardust ~]$ VERSION=1.16.3
-  [isabell@stardust ~]$ mkdir -p ~/gitea
+  [isabell@stardust ~]$ mkdir ~/gitea
   [isabell@stardust ~]$ wget -O ~/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64
-  --2020-06-01 21:00:31--  https://github.com/go-gitea/gitea/releases/download/vX.Y.Z/gitea-X.Y.Z-linux-amd64
-  Resolving github.com (github.com)... 140.82.118.3
-  Connecting to github.com (github.com)|140.82.118.3|:443... connected.
-  HTTP request sent, awaiting response... 302 Found
-  Location: [...]
-  HTTP request sent, awaiting response... 200 OK
-  Length: 83243800 (79M) [application/octet-stream]
+  [...]
   Saving to: ‘/home/isabell/gitea/gitea’
 
-  100%[====================================================================================================================>] 83,243,800  14.9MB/s   in 9.8s
+  100%[========================================================>] 83,243,800  14.9MB/s   in 9.8s
 
   2020-06-01 21:00:42 (8.11 MB/s) - ‘/home/isabell/gitea/gitea’ saved [83243800/83243800]
-  [isabell@stardust ~]$ wget -O ~/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64.asc
-  Resolving github.com (github.com)... 140.82.118.4
-  Connecting to github.com (github.com)|140.82.118.4|:443... connected.
-  HTTP request sent, awaiting response... 302 Found
-  Location: [...]
-  HTTP request sent, awaiting response... 200 OK
-  Length: 833 [application/octet-stream]
-  Saving to: ‘/home/isabell/gitea/gitea.asc’
-
-  100%[====================================================================================================================>] 833         --.-K/s   in 0s
-
-  2020-06-01 21:03:17 (9.01 MB/s) - ‘/home/isabell/gitea/gitea.asc’ saved [833/833]
   [isabell@stardust ~]$
 
-We use ``gpg`` to download the pgp key and verify our download.
-
-.. code-block:: console
-
-  [isabell@stardust ~]$ curl --silent https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2 | gpg --import
-  gpg: directory `/home/isabell/.gnupg' created
-  gpg: new configuration file `/home/isabell/.gnupg/gpg.conf' created
-  gpg: WARNING: options in `/home/isabell/.gnupg/gpg.conf' are not yet active during this run
-  gpg: keyring `/home/isabell/.gnupg/secring.gpg' created
-  gpg: keyring `/home/isabell/.gnupg/pubring.gpg' created
-  gpg: requesting key EC1592E2 from hkp server keys.gnupg.net
-  gpg: /home/isabell/.gnupg/trustdb.gpg: trustdb created
-  gpg: key EC1592E2: public key "Teabot <teabot@gitea.io>" imported
-  gpg: no ultimately trusted keys found
-  gpg: Total number processed: 1
-  gpg:               imported: 1  (RSA: 1)
-  [isabell@stardust ~]$ gpg --verify ~/gitea/gitea.asc ~/gitea/gitea
-  gpg: Signature made Sat 09 May 2020 10:19:06 PM CEST using RSA key ID 9753F4B0
-  gpg: Good signature from "Teabot <teabot@gitea.io>"
-  gpg: WARNING: This key is not certified with a trusted signature!
-  gpg:          There is no indication that the signature belongs to the owner.
-  Primary key fingerprint: 7C9E 6815 2594 6888 62D6  2AF6 2D9A E806 EC15 92E2
-       Subkey fingerprint: CC64 B1DB 67AB BEEC AB24  B645 5FC3 4632 9753 F4B0
-  [isabell@stardust ~]$
-
-If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot@gitea.io>"`` line and we make the bin executable.
+Make the binary executable:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ chmod u+x ~/gitea/gitea
   [isabell@stardust ~]$
 
+| Optionally we can download the pgp signature file, trust key and verify our download with ``gpg``.
+| If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot@gitea.io>"`` line.
+| For this execute the following commands.
+
+.. code-block:: console
+
+  [isabell@stardust ~]$ wget -O ~/gitea/gitea.asc https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64.asc
+  [isabell@stardust ~]$ curl --silent https://keys.openpgp.org/vks/v1/by-fingerprint/7C9E68152594688862D62AF62D9AE806EC1592E2 | gpg --import
+  [isabell@stardust ~]$ gpg --verify ~/gitea/gitea.asc ~/gitea/gitea
 
 Configuration
 =============

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -128,10 +128,7 @@ If the verification is fine, we get a ``gpg: Good signature from "Teabot <teabot
 Configuration
 =============
 
-Gitea configuration file
--------------------------
-
-Before we write the configuration we need the MySQL database password from earlier as well as some random characters as security key.
+We will need to create some random characters as a security key for the configuration:
 
 .. code-block:: console
 
@@ -139,23 +136,21 @@ Before we write the configuration we need the MySQL database password from earli
   <RANDOM_64_CHARACTERS_FROM_GENERATOR>
   [isabell@stardust ~]$
 
-Create a custom directory.
+Copy or save the output for later.
+
+Gitea configuration file
+-------------------------
+
+Create a custom directory for your configurations:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ mkdir --parents ~/gitea/custom/conf/
   [isabell@stardust ~]$
 
-Create ``~/gitea/custom/conf/app.ini`` with the content of the following code block:
-We improve the configuration with some modifications, e.g.:
+Create a config file ``~/gitea/custom/conf/app.ini`` with the content of the following code block:
 
-* Filling the database access data that we would otherwise enter in the web installation step. (``[database]`` section)
-* As security feature we lock the web installation and change the default password complexity to allow well to remember and secure passwords. (See `XKCD No. 936 <https://xkcd.com/936/>`_  and `Explained XKCD No. 936 <https://explainxkcd.com/wiki/index.php/936:_Password_Strength>`_ for the math behind it. 😉 ``[security]`` section)
-* We disallow public registration and set some privacy settings. (``[service]`` section)
-
-For more information about the possibilities and configuration options see the Gitea documentation_ and the Gitea `configuration sample <https://github.com/go-gitea/gitea/blob/master/custom/conf/app.example.ini>`_.
-
-.. warning:: Replace ``isabell`` with your username, fill the database password ``PASSWD =`` with yours and enter the generated random into ``SECRET_KEY =``.
+.. note:: Replace ``isabell`` with your username, fill the database password ``PASSWD =`` with yours and enter the generated random into ``SECRET_KEY =``.
 
 .. code-block:: ini
   :emphasize-lines: 2,9-11,17,25,30
@@ -175,8 +170,8 @@ For more information about the possibilities and configuration options see the G
   [security]
   INSTALL_LOCK        = true
   MIN_PASSWORD_LENGTH = 8
-  PASSWORD_COMPLEXITY = lower
-  SECRET_KEY          = <RANDOM_64_CHARACTERS_FROM_GENERATOR>
+  PASSWORD_COMPLEXITY = lower ; This allows well to remember but still secure passwords
+  SECRET_KEY          = <RANDOM_64_CHARACTERS_FROM_GENERATOR> ; the before generated security key
 
   [service]
   DISABLE_REGISTRATION       = true ; security option, only admins can create new users.
@@ -194,40 +189,40 @@ For more information about the possibilities and configuration options see the G
   [repository]
   DEFAULT_BRANCH = main
 
-Gitea initialization
---------------------
+.. note::
 
-Above we locked the registration and the web installation feature, so this service will never be exposed in an insecure way to the internet. We create the database layout by running the migrate command without running the server.
+  This config block contains a secure and convenient basic configuration. You may change it depending on your needs and knowledge.
+  See the Gitea documentation_ and the Gitea `configuration sample <https://github.com/go-gitea/gitea/blob/master/custom/conf/app.example.ini>`_
+  for more configuration possibilities.
+
+Database initialization
+-----------------------
+
+Migrate the database configurations:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ ~/gitea/gitea migrate
-  ... a lot of console output about the database commands.
+  [...]
+  2022/03/15 11:59:06 models/db/engine.go:194:InitEngineWithMigration() [I] [SQL] CREATE TABLE IF NOT EXISTS `upload` (`id` BIGINT(20) PRIMARY KEY AUTO_INCREMENT NOT NULL , `uuid` VARCHAR(40) NULL , `name` VARCHAR(255) NULL ) ENGINE=InnoDB DEFAULT CHARSET utf8mb4 ROW_FORMAT=DYNAMIC [] - 44.298441ms
+  2022/03/15 11:59:06 models/db/engine.go:194:InitEngineWithMigration() [I] [SQL] CREATE UNIQUE INDEX `UQE_upload_uuid` ON `upload` (`uuid`) [] - 30.158825ms
   [isabell@stardust ~]$
 
 Gitea admin user
 ----------------
 
-Here we set our admin login credentials:
-Gitea does not allow ``admin`` as name.
+Set your admin login credentials:
 
 .. code-block:: console
 
   [isabell@stardust ~]$ ADMIN_USERNAME=AdminUsername
   [isabell@stardust ~]$ ADMIN_PASSWORD='SuperSecretAdminPassword'
-  [isabell@stardust ~]$
-
-Now we create an admin user via Gitea `command line <https://docs.gitea.io/en-us/command-line/#admin>`_. To ensure we remember the password beyond this installation session we store the password in a text file.
-
-.. code-block:: console
-
   [isabell@stardust ~]$ ~/gitea/gitea admin user create --username ${ADMIN_USERNAME} --password ${ADMIN_PASSWORD} --email ${USER}@uber.space --admin
   [isabell@stardust ~]$
-  ...
-  New user 'adminuser' has been successfully created!
-  [isabell@stardust ~]$ echo "usr: ${ADMIN_USERNAME}" > ~/gitea/gitea-admin.txt
-  [isabell@stardust ~]$ echo "pwd: ${ADMIN_PASSWORD}" >> ~/gitea/gitea-admin.txt
-  [isabell@stardust ~]$
+
+.. note::
+
+  Gitea does not allow ``admin`` as name, of course you should choose and replace the password.
 
 Finishing installation
 ======================

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -346,6 +346,36 @@ Installed files and folders are:
 * ``~/etc/services.d/gitea.ini``
 * ``~/.gem/ruby/2.7.0/*/asciidoctor*``, if AsciiDoctor is installed.
 
+Backup
+======
+
+The Gitea CLI (command line interface) has a build-in backup command to create a full backup in a zip file with the database, repos, config, log, data
+
+.. note:: To restore a backup follow the `backup and restore documentation <https://docs.gitea.io/en-us/backup-and-restore/#restore-command-restore>`_
+
+Execute the following command:
+
+::
+
+  [isabell@stardust ~]$ ~/gitea/gitea dump
+  2022/03/08 17:26:01 ...dules/setting/log.go:283:newLogService() [I] Gitea v1.16.3 built with GNU Make 4.1, go1.17.7 : bindata, sqlite, sqlite_unlock_notify
+  [...]
+  2022/03/08 17:26:01 ...s/storage/storage.go:171:initAttachments() [I] Initialising Attachment storage with type:
+  2022/03/08 17:26:01 ...les/storage/local.go:46:NewLocalStorage() [I] Creating new Local Storage at /home/isabell/gitea/data/attachments
+  2022/03/08 17:26:01 ...s/storage/storage.go:165:initAvatars() [I] Initialising Avatar storage with type:
+  2022/03/08 17:26:01 ...les/storage/local.go:46:NewLocalStorage() [I] Creating new Local Storage at /home/isabell/gitea/data/avatars
+  2022/03/08 17:26:01 ...s/storage/storage.go:183:initRepoAvatars() [I] Initialising Repository Avatar storage with type:
+  2022/03/08 17:26:01 ...les/storage/local.go:46:NewLocalStorage() [I] Creating new Local Storage at /home/isabell/gitea/data/repo-avatars
+  2022/03/08 17:26:01 ...s/storage/storage.go:177:initLFS() [I] Initialising LFS storage with type:
+  2022/03/08 17:26:01 ...les/storage/local.go:46:NewLocalStorage() [I] Creating new Local Storage at /home/isabell/gitea/data/lfs
+  2022/03/08 17:26:01 ...s/storage/storage.go:189:initRepoArchives() [I] Initialising Repository Archive storage with type:
+  2022/03/08 17:26:01 ...les/storage/local.go:46:NewLocalStorage() [I] Creating new Local Storage at /home/isabell/gitea/data/repo-archive
+  2022/03/08 17:26:01 cmd/dump.go:270:runDump() [I] Dumping database...
+  [...]
+  2022/03/08 17:26:01 cmd/dump.go:282:runDump() [I] Adding custom configuration file from /home/isabell/gitea/custom/conf/app.ini
+  2022/03/08 17:26:01 cmd/dump.go:310:runDump() [I] Packing data directory.../home/isabell/gitea/data
+  2022/03/08 17:26:01 cmd/dump.go:379:runDump() [I] Finish dumping in file gitea-dump-1646756761.zip
+  [isabell@stardust ~]$
 
 Updates
 =======


### PR DESCRIPTION
Changes:
- fix GPG key import
- add backup section
- add `gitea-update` script
  tested by updating 1.14.4 to 1.16.3

[👀 deploy preview](https://deploy-preview-1215--uberlab.netlify.app/guide_gitea.html)

- [x] closes #1219
- [x] guide is working with a new asteroid 🪨
  tested via
  ```bash
  bash -c "$(wget -q -O - https://github.com/EV21/uberspace-helper/raw/main/uberspace-gitea-installer.sh)"
  ```
  with
  ```bash
  GITHUB_API_URL=https://api.github.com/repos/$ORG/$REPO/releases/tags/v1.14.4
  GITHUB_API_URL=https://api.github.com/repos/$ORG/$REPO/releases/latest
  ```
- [x] run `make clean html` without relevant warnings
- [x] run `make spelling` without relevant warnings