### PR TITLE
[mailman] configure max SMTP recipients limit

### DIFF
--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -163,6 +163,7 @@ At first, we need to configure the REST interface of the core component. Create 
  smtp_secure_mode: starttls
  smtp_user: forwarder@isabell.uber.space
  smtp_pass: mailpassword
+ max_recipients: 100
 
  [webservice]
  hostname: 0.0.0.0
@@ -215,7 +216,7 @@ HyperKitty is the part of mailman that takes care of archiving mail. It is confi
 Daemonizing Mailman Core
 ------------------------
 
-As we want to make sure that Mailman is started automatically, we need to set it up as a service. Due to mailman executable not having having the option to always run in foreground, we need some other means of controlling it. The process controlling all forked processes is located at ``~/.local/bin/master``. We therefore need to create the supervisord config file for mailman in ``~/etc/services.d/mailman3.ini`` as follows:
+As we want to make sure that Mailman is started automatically, we need to set it up as a service. Due to mailman executable not having the option to always run in foreground, we need some other means of controlling it. The process controlling all forked processes is located at ``~/.local/bin/master``. We therefore need to create the supervisord config file for mailman in ``~/etc/services.d/mailman3.ini`` as follows:
 
 .. code :: ini
 

--- a/source/guide_mailman.rst
+++ b/source/guide_mailman.rst
@@ -222,6 +222,7 @@ Add the following options to the end of the file ``/var/www/virtual/$USER/mailma
  SMTP_USE_TLS = True
  SMTPHOST = 'stardust.uberspace.de'
  SMTPPORT = '587'
+ SMTP_MAX_RCPTS = 100
 
  SMTP_USER = 'mailmanbox@isabell.uber.space'
  SMTP_PASSWD = 'MySuperSecretPassword'


### PR DESCRIPTION
The Uberspace SMTP servers accept max 100 recipients per mail. This PR updates the Lab guide for Mailman2 and Mailman3 to reflect these limits.