### PR TITLE
Update guide_seafile.rst

### DIFF
--- a/source/guide_seafile.rst
+++ b/source/guide_seafile.rst
@@ -81,7 +81,7 @@ Install the required python libraries.
 
 ::
 
- [isabell@stardust seafile]$ pip3 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
+ [isabell@stardust seafile]$ pip3 install --upgrade pip Pillow==8.2.0 pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
  [isabell@stardust seafile]$
 
 Create databases


### PR DESCRIPTION
Added version to `pip3 install Pillow` because `seahub.sh` will not start when a newer package is installed. 
Beware of blindly initiated updates! This way I was caught by this problem. Took me two days to figure it out.