### PR TITLE
[seafile] update guide

### DIFF
--- a/source/guide_seafile.rst
+++ b/source/guide_seafile.rst
@@ -89,8 +89,10 @@ Install the required python libraries.
 
 ::
 
- [isabell@stardust seafile]$ pip3.8 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
+ [isabell@stardust seafile]$ pip3.8 install --upgrade pip Pillow captcha jinja2 sqlalchemy==1.4.3 django-simple-captcha python3-ldap mysqlclient --user
  [isabell@stardust seafile]$
+
+.. note:: Two depencies, ``pylibmc`` and ``django-pylibmc`` cannot be installed because they would require the system packages ``memcached`` and ``libmemcached-devel`` to be installed on Uberspace. This is okay because memcached support in Seafile is `optional <https://manual.seafile.com/deploy/add_memcached/>`_ and only recommended for installations with more than 50 users.
 
 Create databases
 ----------------
@@ -231,7 +233,7 @@ Updating seafile is pretty easy. First update the pip3 packages, then download t
 
 ::
 
- [isabell@stardust ~]$ pip3.8 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
+ [isabell@stardust ~]$ pip3.8 install --upgrade pip Pillow captcha jinja2 sqlalchemy==1.4.3 django-simple-captcha python3-ldap mysqlclient --user
  [isabell@stardust ~]$ cd ~/seafile/
  [isabell@stardust seafile]$ curl https://download.seadrive.org/seafile-server_8.0.7_x86-64.tar.gz | tar xzf -
  [isabell@stardust seafile]$ ln -sfn /home/seafile/seafile/seafile-server-8.0.7 /home/seafile/seafile/seafile-server-latest

--- a/source/guide_seafile.rst
+++ b/source/guide_seafile.rst
@@ -63,7 +63,7 @@ Installation
 Download
 --------
 
-Check the `Seafile website`_ for the latest ``Server for generic Linux`` release, copy the download link and replace the URL in the following command with the one you just copied.
+Check the `Seafile website`_ for the latest ``Server for generic Linux`` release, copy the download link and replace the URL in the following command with the one you just copied. (This guide was tested with release 8.0.8.)
 
 .. _Seafile website: https://www.seafile.com/en/download/
 
@@ -71,7 +71,7 @@ Check the `Seafile website`_ for the latest ``Server for generic Linux`` release
 
  [isabell@stardust ~]$ mkdir seafile
  [isabell@stardust ~]$ cd seafile/
- [isabell@stardust seafile]$ curl https://download.seadrive.org/seafile-server_8.0.7_x86-64.tar.gz | tar xzf -
+ [isabell@stardust seafile]$ curl https://download.seadrive.org/seafile-server_8.0.8_x86-64.tar.gz | tar xzf -
  [isabell@stardust seafile]$
 
 Install dependencies

--- a/source/guide_seafile.rst
+++ b/source/guide_seafile.rst
@@ -77,11 +77,19 @@ Check the `Seafile website`_ for the latest ``Server for generic Linux`` release
 Install dependencies
 --------------------
 
+.. note:: Parts of Seafile call ``python3``, but don't work with Python 3.6, which is the version the default alias on Uberspace resolves to. A local symlink to ``python3.8`` and using ``pip3.8`` instead of just ``pip3`` remedy this. (Make sure that no other service depends on ``python3`` pointing to ``python3.6``!)
+
+First, create a symlink to ``python3``.
+
+::
+
+ [isabell@stardust seafile]$ ln -s /usr/bin/python3.8 $HOME/bin/python3
+
 Install the required python libraries.
 
 ::
 
- [isabell@stardust seafile]$ pip3 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
+ [isabell@stardust seafile]$ pip3.8 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
  [isabell@stardust seafile]$
 
 Create databases
@@ -223,7 +231,7 @@ Updating seafile is pretty easy. First update the pip3 packages, then download t
 
 ::
 
- [isabell@stardust ~]$ pip3 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
+ [isabell@stardust ~]$ pip3.8 install --upgrade pip Pillow pylibmc captcha jinja2 sqlalchemy==1.4.3 django-pylibmc django-simple-captcha python3-ldap mysqlclient --user
  [isabell@stardust ~]$ cd ~/seafile/
  [isabell@stardust seafile]$ curl https://download.seadrive.org/seafile-server_8.0.7_x86-64.tar.gz | tar xzf -
  [isabell@stardust seafile]$ ln -sfn /home/seafile/seafile/seafile-server-8.0.7 /home/seafile/seafile/seafile-server-latest

--- a/source/guide_seafile.rst
+++ b/source/guide_seafile.rst
@@ -143,9 +143,9 @@ Important answers:
 Configure
 ---------
 
-Enter your domain name in config; Edit ``~/seafile/conf/ccnet.conf``
+Enter your domain name in config, if you haven't already done that when running the installer script above; Edit ``~/seafile/conf/ccnet.conf``
 
-.. warning:: Replace ``isabell`` with your username!
+.. warning:: Replace ``isabell`` with your username, and if you are using a custom domain, use it in place of ``isabell.user.space``!
 
 .. code-block:: console
 


### PR DESCRIPTION
The current version of the Seafile guide doesn't work because of incompatibilities with python3.6 and the system requirement of `memcached` and `libmemcached-devel` not being satisfied on Uberspace.