### PR TITLE
[friendica] fix guide - closes #1254

### DIFF
--- a/source/guide_friendica.rst
+++ b/source/guide_friendica.rst
@@ -19,12 +19,6 @@ Friendica
 
 .. tag_list::
 
-.. error::
-
-  This guide seems to be **broken** for the current versions of XYZ, we would be
-  happy if you want to work on a solution and create a Pull Request.
-  See also the related issue: https://github.com/Uberspace/lab/issues/1254
-
 Friendica_ is a free and open-source distributed social network.
 It has built-in support for ActivityPub (e.g. Funkwhale, Hubzilla,
 Mastodon, Pleroma, Pixelfed), OStatus (e.g. StatusNet, GNU social,
@@ -53,12 +47,13 @@ repository of the project.
 Prerequisites
 =============
 
-We're using :manual:`PHP <lang-php>` in the stable version 7.4:
+We're using :manual:`PHP <lang-php>` in the stable version 8.1:
 
 ::
 
- [isabell@stardust ~]$ uberspace tools version show php
- Using 'PHP' version: '7.4'
+ [isabell@stardust ~]$ uberspace tools version use php 8.1
+ Selected PHP version 8.1
+ The new configuration is adapted immediately. Patch updates will be applied automatically.
  [isabell@stardust ~]$
 
 .. include:: includes/my-print-defaults.rst
@@ -256,6 +251,6 @@ This is a list of files you need to restore your friendica node:
 
 ----
 
-Tested with Friendica 2021.09, Uberspace 7.12.0
+Tested with Friendica 2022.03, Uberspace 7.12.1
 
 .. author_list::


### PR DESCRIPTION
Hi,

the latest stable release of friendica now supports PHP 8 and a vendored library requires it, so using PHP 7.4 in the guide has been the problem. I've fixed this now.

Regards,
Tobias
