### PR TITLE
Change of SMTP option regarding SSL

### DIFF
--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -92,7 +92,7 @@ Use your favourite editor to create ``~/vaultwarden/output/.env`` with the follo
  SMTP_HOST=stardust.uberspace.de
  SMTP_FROM=isabell@uber.space
  SMTP_PORT=587
- SMTP_SSL=true
+ SMTP_SECURITY=starttls
  SMTP_USERNAME=isabell@uber.space
  SMTP_PASSWORD=MySuperSecretPassword
  DOMAIN=https://isabell.uber.space


### PR DESCRIPTION
Accroding the logs from vaultwarden, installed today, the SMTP_SSL option is deprecated. Original log output:
DEPRECATED]: `SMTP_SSL` or `SMTP_EXPLICIT_TLS` is set. Please use `SMTP_SECURITY` instead.

The installed vaultwarden was not able to send emails, error: [2022-06-27 22:12:30.828][vaultwarden::mail][ERROR] SMTP network error: Resource temporarily unavailable (os error 11)

With the changed SMTP option, everything works fine.