### PR TITLE
[Nextcloud] Workaround for hanging contacts app

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -482,6 +482,20 @@ The update to Nextcloud 21.0.1 may fail with the following error message:
 
 To solve the issue, apply the ``apc.enable_cli=1`` step above to your installation.
 
+Contacts app hangs
+------------------
+
+When your instance is hanging when you open the contacts app you might be affected by `Nextcloud issue #33048 <https://github.com/nextcloud/server/issues/33048>`_
+
+As a workaround you can remove or override ``ErrorDocument`` entries in the ``.htaccess`` file:
+
+.. code-block:: bash
+
+ ErrorDocument 403 "Forbidden"
+ ErrorDocument 404 "Not found"
+
+You need to reapply these changes after you installed Nextcloud updates or after you executed the ``maintenance:update:htaccess`` command.
+
 .. _ownCloud: https://owncloud.org
 .. _Nextcloud: https://nextcloud.com
 .. _`system requirements`: https://docs.nextcloud.com/server/latest/admin_manual/installation/system_requirements.html


### PR DESCRIPTION
See https://github.com/nextcloud/server/issues/33048 for more background.

In a Nutshell:

* The contacts app makes many requests to load contact images like `/remote.php/dav/addressbooks/users/<user>/<Addressbook>/<contact-uid>.vcf?photo=`
* The `ProxyErrorOverride` config in Uberspace accounts hides the 404 error thrown by Nextcloud and opens the configured `ErrorDocument` from `.htaccess`
* The default error document redirects the user to the Nextcloud start page (Dashboard)
* This means a lot of requests are made at once to load the Nextcloud dashboard which can lead to a completely hung up Nextcloud instance until restarting the PHP service with `uberspace tools restart php`