### PR TITLE
Update guide_postgresql.rst: fix postgresql.ini

### DIFF
--- a/source/guide_postgresql.rst
+++ b/source/guide_postgresql.rst
@@ -212,7 +212,7 @@ Create ``~/etc/services.d/postgresql.ini`` with the following content:
  command=postgres -D %(ENV_HOME)s/opt/postgresql/data/
  autostart=yes
  autorestart=yes
- startsec=15
+ startsecs=15
 
 .. include:: includes/supervisord.rst
 


### PR DESCRIPTION
It's `startsecs` not `startsec`.