### PR TITLE
[Gitea] fix stop signal

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -168,9 +168,6 @@ Create a config file ``~/gitea/custom/conf/app.ini`` with the content of the fol
   MAILER_TYPE = sendmail
   FROM        = isabell@uber.space
 
-  [repository]
-  DEFAULT_BRANCH = main
-
 .. note::
 
   This config block contains a secure and convenient basic configuration. You may change it depending on your needs and knowledge.

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -220,7 +220,6 @@ To keep Gitea up and running in the background, you need to create a service tha
   directory=%(ENV_HOME)s/gitea
   command=%(ENV_HOME)s/gitea/gitea web
   startsecs=30
-  stopsignal=HUP
   autorestart=yes
 
 .. include:: includes/supervisord.rst

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -60,7 +60,7 @@ Check current version of Gitea at releases_ page:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ VERSION=1.16.3
+  [isabell@stardust ~]$ VERSION=1.17.2
   [isabell@stardust ~]$ mkdir ~/gitea
   [isabell@stardust ~]$ wget -O ~/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64
   [...]
@@ -380,8 +380,19 @@ You can also automate the update by using a custom script that automatically exe
       head --lines=1)" != "$1"
   }
 
+  function fix_stop_signal
+  {
+    if (grep --quiet HUP "$HOME"/etc/services.d/gitea.ini)
+    then
+      sed --in-place '/HUP/d' "$HOME"/etc/services.d/gitea.ini
+      supervisorctl reread
+      supervisorctl update
+    fi
+  }
+
   function main
   {
+    fix_stop_signal
     get_local_version
     get_latest_version
 


### PR DESCRIPTION
The HUP signal may result into forking the process into the backgroud, so it breaks the daemon when updating your instance.
Restarting or reloading are failing as the port is still in use by the forked instance.
https://github.com/alpinelinux/aports/commit/8a8c116a951f8c8a53be667e4697a76c97db93dc

Quick test:
```
bash -c "$(wget -q -O - https://sh.ev21.de/uberspace/gitea-installer.sh)" _ use 1.16.8
```
```
gitea-update
```

With this fix updates should run without any headaches.

[👀 deploy preview](https://deploy-preview-1314--uberlab.netlify.app/guide_gitea)