### PR TITLE
[nextcloud] add random sleep to cronjob in guide_nextcloud.rst close #1318

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -249,7 +249,7 @@ Add the following cronjob to your :manual:`crontab <daemons-cron>`:
 
 ::
 
- */5  *  *  *  * php -f $HOME/html/cron.php > $HOME/logs/nextcloud-cron.log 2>&1
+ */5  *  *  *  * sleep $(( 1 + $RANDOM \% 60 )) ; php -f $HOME/html/cron.php > $HOME/logs/nextcloud-cron.log 2>&1
 
 Configure Nextcloud to rely on the configured cronjob:
 

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -251,6 +251,8 @@ Add the following cronjob to your :manual:`crontab <daemons-cron>`:
 
  */5  *  *  *  * sleep $(( 1 + $RANDOM \% 60 )) ; php -f $HOME/html/cron.php > $HOME/logs/nextcloud-cron.log 2>&1
 
+.. note:: The actual cronjob is preceded by a random sleep of maximum one minute to prevent load peaks every 5 minutes due to simultaneous execution of all cronjobs. 
+
 Configure Nextcloud to rely on the configured cronjob:
 
 ::


### PR DESCRIPTION
add `sleep $(( 1 + $RANDOM \% 60 )) ;` to cronjob and explain why.