### PR TITLE
[Nextcloud] make install command parameters bulletproof

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -167,10 +167,10 @@ Now, execute the Nextcloud maintenance PHP script ``occ`` with the parameters sh
 .. code-block:: console
   :emphasize-lines: 1-3
 
-  [isabell@stardust html]$ NEXTCLOUD_ADMIN_USER=MyUserName
-  [isabell@stardust html]$ NEXTCLOUD_ADMIN_PASS=MySuperSecretAdminPassword
-  [isabell@stardust html]$ MYSQL_PASSWORD=MySuperSecretMySQLPassword
-  [isabell@stardust html]$ php occ maintenance:install --admin-user "${NEXTCLOUD_ADMIN_USER}" --admin-pass "${NEXTCLOUD_ADMIN_PASS}" --database 'mysql' --database-name "${USER}_nextcloud"  --database-user "${USER}" --database-pass "${MYSQL_PASSWORD}" --data-dir "${HOME}/nextcloud_data"
+  [isabell@stardust html]$ NEXTCLOUD_ADMIN_USER='MyUserName'
+  [isabell@stardust html]$ NEXTCLOUD_ADMIN_PASS='MySuperSecretAdminPassword'
+  [isabell@stardust html]$ MYSQL_PASSWORD='MySuperSecretMySQLPassword'
+  [isabell@stardust html]$ php occ maintenance:install --admin-user="${NEXTCLOUD_ADMIN_USER}" --admin-pass="${NEXTCLOUD_ADMIN_PASS}" --database='mysql' --database-name="${USER}_nextcloud"  --database-user="${USER}" --database-pass="${MYSQL_PASSWORD}" --data-dir="${HOME}/nextcloud_data"
   Nextcloud was successfully installed
   [isabell@stardust html]$
 

--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -249,7 +249,7 @@ Add the following cronjob to your :manual:`crontab <daemons-cron>`:
 
 ::
 
- */5  *  *  *  * sleep $(( 1 + $RANDOM \% 60 )) ; php -f $HOME/html/cron.php > $HOME/logs/nextcloud-cron.log 2>&1
+ */5  *  *  *  * sleep $(( 1 + RANDOM % 60 )) ; php -f $HOME/html/cron.php > $HOME/logs/nextcloud-cron.log 2>&1
 
 .. note:: The actual cronjob is preceded by a random sleep of maximum one minute to prevent load peaks every 5 minutes due to simultaneous execution of all cronjobs.
 


### PR DESCRIPTION
In my test run my credentials are

```sh
[test42@hadar html]$ my_print_defaults client
--default-character-set=utf8mb4
--user=test42
--password=-M,W:YO9123456.TZz1C
[test42@hadar html]$ NEXTCLOUD_ADMIN_USER='Testadminuser'
[test42@hadar html]$ NEXTCLOUD_ADMIN_PASS='superUnSafePässwörd'
[test42@hadar html]$ MYSQL_PASSWORD='-M,W:YO9123456.TZz1C'
```

The `--database-pass[=DATABASE-PASS]` has an optional argument (not like the other ones) and in my case the password starts with `-M,` so the Symfony CLI logic sees this thing as flag

![grafik](https://user-images.githubusercontent.com/8345730/197134897-9e575528-9cdf-4b72-9d63-d399e818322b.png)

with `=` it works
![grafik](https://user-images.githubusercontent.com/8345730/197134562-2c5850eb-ac85-48d1-8847-876d8e7b41ba.png)

Since the official documentation also uses the space separation it looks like a bug.
https://docs.nextcloud.com/server/latest/admin_manual/installation/command_line_installation.html

Maybe just let us use the bulletproof connected variant to avoid these cases when the password generator likes to have a `-` at the beginning 🤣 (It is not the first time I got a password like that, I also got it once on U5/U6 too)

![grafik](https://user-images.githubusercontent.com/8345730/197250281-ec7aa9bd-4691-45c3-bf33-6a36bab7782d.png)

---

[deploy preview 👀](https://deploy-preview-1332--uberlab.netlify.app/guide_nextcloud/)