### PR TITLE
Add link to project website

### DIFF
--- a/source/guide_hugo.rst
+++ b/source/guide_hugo.rst
@@ -19,7 +19,7 @@ Hugo
 
 .. tag_list::
 
-Hugo is a fast and modern static site generator written in Go, and designed to make website creation fun again.
+Hugo_ is a fast and modern static site generator written in Go, and designed to make website creation fun again.
 
 ----
 


### PR DESCRIPTION
The descripition page does not contain a link to the project website. It would be helpful for the users to quickly have a look to a project by such a link.