### PR TITLE
[restic] use full path in backup script

### DIFF
--- a/source/guide_restic.rst
+++ b/source/guide_restic.rst
@@ -117,7 +117,7 @@ It is recommended to create a script to automate the backups. Please edit this t
   FILES='/var/www/virtual/isabell/html/ /home/isabell/myImportantDocument.md'
 
   # Run restic backup
-  restic -r b2:bucketname:path/to/repo backup $FILES
+  ~/bin/restic -r b2:bucketname:path/to/repo backup $FILES
 
   #set +x # Stop printing
 


### PR DESCRIPTION
When following the guide as it is, the cron logs showed the following error:

```
/home/<user>/restic_backup.sh: line 20: restic: command not found
```

This change made the script work in cron for me.

I don't know cron well enough to determine the proper way, so please correct me if there's a better solution.