### PR TITLE
[firefly-iii] Added note how to solve endles redirect issue for `/login`

### DIFF
--- a/source/guide_firefly-iii.rst
+++ b/source/guide_firefly-iii.rst
@@ -101,6 +101,8 @@ Go to https://isabell.uber.space to access your Firefly III installation.
 
 .. warning:: Please make sure to directly create an account, as the first account will be an admin account.
 
+.. note:: If https://isabell.uber.space/login does result into an "Internal Server Error", open the 
+
 Tuning
 ======
 


### PR DESCRIPTION
Added a note in the section `Finishing installation`. I ran into this issue and debugged it to figure out the Solution `RewriteBase /`.

My two cents, I have a slightly different setup with:

* subdomain like `https://my.isabell.uber.space` instead of `https://isabell.uber.space`
* `my.isabell.de` as softlink to `data/de/isabell/my/public` instead of `firefly_iii/public html`