### PR TITLE
[gotify] Updated installation by building from source

### DIFF
--- a/source/guide_gotify.rst
+++ b/source/guide_gotify.rst
@@ -81,7 +81,7 @@ First download the latest version, so everything is prepared:
     inflating: licenses/golang.org_x_crypto
   [isabell@stardust gotify]$
 
-Now we clone the soruces and build them:
+Now we clone the sources and build them:
 
 ::
 

--- a/source/guide_gotify.rst
+++ b/source/guide_gotify.rst
@@ -54,7 +54,9 @@ Note the `--remove-prefix` option here. Without it, gotify will not work behind 
 Installation
 ============
 
-Like a lot of Go software, gotify is distributed as a single binary. Download gotify's latest `release <https://github.com/gotify/server/releases/latest>`_, unzip it and make sure that the file can be executed.
+Like a lot of Go software, gotify is distributed as a single binary. Since version 2.1.7 gotify requires GLIBC 2.28, which is not available in U7. Thus we need to build gotify from source. The building is done as is described on gotify's documentation: https://gotify.net/docs/dev-setup but building without docker and only for one architecture:
+
+First download the latest version, so everything is prepared:
 
 ::
 
@@ -78,6 +80,59 @@ Like a lot of Go software, gotify is distributed as a single binary. Download go
   [...]
     inflating: licenses/golang.org_x_crypto
   [isabell@stardust gotify]$
+
+Now we clone the soruces and build them:
+
+::
+
+  [isabell@stardust ~]$ git clone https://github.com/gotify/server.git
+  [isabell@stardust ~]$ cd server
+  [isabell@stardust ~]$ git checkout v2.2.2
+  Note: switching to 'v2.2.2'.
+  [isabell@stardust ~]$ make download-tools
+  go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1
+  [isabell@stardust ~]$ go get -d
+  [isabell@stardust ~]$ cd ui
+  [isabell@stardust ~]$ yarn
+  yarn install v1.22.19
+  [1/4] Resolving packages...
+  success Already up-to-date.
+  Done in 2.53s.
+  [isabell@stardust ~]$ 
+  [isabell@stardust ~]$ 
+  [isabell@stardust ~]$ yarn build
+  yarn run v1.22.19
+  $ react-scripts build
+  Creating an optimized production build...
+  Browserslist: caniuse-lite is outdated. Please run:
+    npx browserslist@latest --update-db
+    Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
+  Compiled successfully.
+  
+  File sizes after gzip:
+  
+    252.57 KB  build/static/js/2.62492a59.chunk.js
+    15.19 KB   build/static/js/main.d0066ad9.chunk.js
+    2.4 KB     build/static/css/2.0f3898ba.chunk.css
+    778 B      build/static/js/runtime-main.2e858444.js
+  
+  The project was built assuming it is hosted at ./.
+  You can control this with the homepage field in your package.json.
+  
+  The build folder is ready to be deployed.
+  
+  Find out more about deployment here:
+  
+    https://cra.link/deployment
+  
+  Done in 59.93s.
+  [isabell@stardust ~]$ 
+  [isabell@stardust ~]$ 
+  [isabell@stardust ~]$ cd ..
+  [isabell@stardust ~]$ go run hack/packr/packr.go
+  [isabell@stardust ~]$ export LD_FLAGS="-w -s -X main.Version=$(git describe --tags | cut -c 2-) -X main.BuildDate=$(date "+%F-%T") -X main.Commit=$(git rev-parse --verify HEAD) -X main.Mode=prod";
+  [isabell@stardust ~]$ go build -ldflags="$LD_FLAGS" -o gotify-server
+  [isabell@stardust ~]$ mv gotify-server ../gotify-linux-amd64
 
 
 Configuration

--- a/source/guide_gotify.rst
+++ b/source/guide_gotify.rst
@@ -54,53 +54,24 @@ Note the `--remove-prefix` option here. Without it, gotify will not work behind 
 Installation
 ============
 
-Like a lot of Go software, gotify is distributed as a single binary. Since version 2.1.7 gotify requires GLIBC 2.28, which is not available in U7. Thus we need to build gotify from source. The building is done as is described on gotify's documentation: https://gotify.net/docs/dev-setup but building without docker and only for one architecture:
-
-First download the latest version, so everything is prepared:
-
-::
-
-  [isabell@stardust ~]$ mkdir ~/gotify && cd ~/gotify
-  [isabell@stardust gotify]$ wget https://github.com/gotify/server/releases/latest/download/gotify-linux-amd64.zip
-  Resolving github.com (github.com)... 140.82.118.4
-  Connecting to github.com (github.com)|140.82.118.4|:443... connected.
-  HTTP request sent, awaiting response... 302 Found
-  Length: 52960072 (51M) [application/octet-stream]
-  Saving to: gotify-linux-amd64.zip
-
- 100%[==========================================>] 10,200,261  12.0MB/s
-
-  2019-10-26 01:15:11 (12.0 MB/s) - 'gotify-linux-amd64.zip' saved [10200261/10200261]
-  [isabell@stardust gotify]$ unzip gotify-linux-amd64.zip
-  Archive:  gotify-linux-amd64.zip
-    inflating: gotify-linux-amd64
-    inflating: LICENSE
-     creating: licenses/
-    inflating: licenses/github.com_gotify_plugin-api
-  [...]
-    inflating: licenses/golang.org_x_crypto
-  [isabell@stardust gotify]$
-
-Now we clone the sources and build them:
+Like a lot of Go software, gotify is distributed as a single binary. Since version 2.1.7 gotify requires GLIBC 2.28, which is not available in U7. Thus we need to build gotify from source. The building is done as is described in `gotify's documentation <https://gotify.net/docs/dev-setup>`_ but building without docker and only for one architecture:
 
 ::
 
   [isabell@stardust ~]$ git clone https://github.com/gotify/server.git
   [isabell@stardust ~]$ cd server
-  [isabell@stardust ~]$ git checkout v2.2.2
+  [isabell@stardust ~/server]$ git checkout v2.2.2
   Note: switching to 'v2.2.2'.
-  [isabell@stardust ~]$ make download-tools
+  [isabell@stardust server]$ make download-tools
   go install github.com/go-swagger/go-swagger/cmd/swagger@v0.26.1
-  [isabell@stardust ~]$ go get -d
-  [isabell@stardust ~]$ cd ui
-  [isabell@stardust ~]$ yarn
+  [isabell@stardust server]$ go get -d
+  [isabell@stardust server]$ cd ui
+  [isabell@stardust ui]$ yarn
   yarn install v1.22.19
   [1/4] Resolving packages...
   success Already up-to-date.
   Done in 2.53s.
-  [isabell@stardust ~]$ 
-  [isabell@stardust ~]$ 
-  [isabell@stardust ~]$ yarn build
+  [isabell@stardust ~/server/ui]$ yarn build
   yarn run v1.22.19
   $ react-scripts build
   Creating an optimized production build...
@@ -126,13 +97,11 @@ Now we clone the sources and build them:
     https://cra.link/deployment
   
   Done in 59.93s.
-  [isabell@stardust ~]$ 
-  [isabell@stardust ~]$ 
-  [isabell@stardust ~]$ cd ..
-  [isabell@stardust ~]$ go run hack/packr/packr.go
-  [isabell@stardust ~]$ export LD_FLAGS="-w -s -X main.Version=$(git describe --tags | cut -c 2-) -X main.BuildDate=$(date "+%F-%T") -X main.Commit=$(git rev-parse --verify HEAD) -X main.Mode=prod";
-  [isabell@stardust ~]$ go build -ldflags="$LD_FLAGS" -o gotify-server
-  [isabell@stardust ~]$ mv gotify-server ../gotify-linux-amd64
+  [isabell@stardust ui]$ cd ..
+  [isabell@stardust server]$ go run hack/packr/packr.go
+  [isabell@stardust server]$ export LD_FLAGS="-w -s -X main.Version=$(git describe --tags | cut -c 2-) -X main.BuildDate=$(date "+%F-%T") -X main.Commit=$(git rev-parse --verify HEAD) -X main.Mode=prod";
+  [isabell@stardust server]$ go build -ldflags="$LD_FLAGS" -o gotify-server
+  [isabell@stardust server]$ mv gotify-server ../gotify-linux-amd64
 
 
 Configuration

--- a/source/guide_gotify.rst
+++ b/source/guide_gotify.rst
@@ -56,6 +56,11 @@ Installation
 
 Like a lot of Go software, gotify is distributed as a single binary. Since version 2.1.7 gotify requires GLIBC 2.28, which is not available in U7. Thus we need to build gotify from source. The building is done as is described in `gotify's documentation <https://gotify.net/docs/dev-setup>`_ but building without docker and only for one architecture:
 
+.. warning::
+
+  The ``yarn build`` command may fail at first with an ``code: 'EPIPE', syscall: 'write'`` error message.
+  Just run it again until you get ``Done in 60.48s.``. 
+
 ::
 
   [isabell@stardust ~]$ git clone https://github.com/gotify/server.git
@@ -71,7 +76,7 @@ Like a lot of Go software, gotify is distributed as a single binary. Since versi
   [1/4] Resolving packages...
   success Already up-to-date.
   Done in 2.53s.
-  [isabell@stardust ~/server/ui]$ yarn build
+  [isabell@stardust ~/server/ui]$ NODE_OPTIONS=--openssl-legacy-provider yarn build
   yarn run v1.22.19
   $ react-scripts build
   Creating an optimized production build...


### PR DESCRIPTION
We need to build from source since version gotify 2.1.7 as the released version requires GLIBC 2.28. Hopefully gotify won't use a glibc ABI only available in 2.28...