### PR TITLE
[vaultwarden] Improve updateability

### DIFF
--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -62,7 +62,7 @@ Create a directory in ``/home/isabell`` for vaultwarden. In the vaultwarden dire
  [isabell@stardust ~]$ mkdir ~/vaultwarden/data
  [isabell@stardust ~]$
 
-Download the Docker Image Extractor
+Download the Docker Image Extractor.
 
 .. code-block:: console
 
@@ -84,7 +84,9 @@ Change into the ``~/vaultwarden`` directory. Fetch and extract the binary from t
   Image contents extracted into ./output.
   [isabell@stardust vaultwarden]$
 
-Setup E-Mail for notifications.
+Update default configuration
+----------------------------
+
 Use your favourite editor to create ``~/vaultwarden/.env`` with the following content:
 
 .. code-block:: ini
@@ -222,7 +224,7 @@ Disable registration and invitations
 
 By default, vaultwarden allows any anonymous user to register new accounts on the server without first being invited. **This is necessary to create your first user on the server**, but it's recommended to disable it in the admin panel (if the admin panel is enabled) or with the environment variable to prevent attackers from creating accounts on your vaultwarden server.
 
-Use your favourite editor to edit ``~/vaultwarden/output/.env`` and add the following content:
+Use your favourite editor to edit ``~/vaultwarden/.env`` and add the following content:
 
 .. code-block:: ini
 
@@ -248,7 +250,7 @@ Disable password hint display
 
 vaultwarden displays password hints on the login page to accommodate small/local deployments that do not have SMTP configured, which could be abused by an attacker to facilitate password-guessing attacks against users on the server. This can be disabled in the admin panel by unchecking the ``Show password hints option`` or with the environment variable:
 
-Use your favourite editor to edit ``~/vaultwarden/output/.env`` and add the the following content:
+Use your favourite editor to edit ``~/vaultwarden/.env`` and add the the following content:
 
 .. code-block:: ini
 

--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -265,9 +265,6 @@ Updating vaultwarden is really easy.
   - Pull latest image and extract binary
   - Start the server again
 
-To get the download link for the newest version of the web-vault look here web-vault-feed_.
-
-
 .. code-block:: console
 
  [isabell@stardust ~]$ cd ~/vaultwarden

--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -126,9 +126,11 @@ Setup web vault
 
 Now it's time to test if everything works.
 
+.. note :: Setting both ``ENV_FILE`` and ``DATA_FOLDER`` as temporary environment variables is necessary for vaultwarden to find the correct config and data directory.
+
 .. code-block:: console
 
- [isabell@stardust ~]$ export ENV_FILE=$HOME/vaultwarden.env
+ [isabell@stardust ~]$ export ENV_FILE=$HOME/vaultwarden/.env
  [isabell@stardust ~]$ export DATA_FOLDER=$HOME/vaultwarden/data
  [isabell@stardust ~]$ cd ~/vaultwarden/output
  [isabell@stardust output]$ ./vaultwarden

--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -54,11 +54,12 @@ Install vaultwarden
 
 We will be installing vaultwarden by extracting a standalone, statically-linked binary from the official Docker image.
 
-Create a directory in ``/home/isabell`` for vaultwarden and its files.
+Create a directory in ``/home/isabell`` for vaultwarden. In the vaultwarden directory, also create a directory to store the actual data.
 
 .. code-block:: console
 
  [isabell@stardust ~]$ mkdir ~/vaultwarden
+ [isabell@stardust ~]$ mkdir ~/vaultwarden/data
  [isabell@stardust ~]$
 
 Download the Docker Image Extractor
@@ -84,7 +85,7 @@ Change into the ``~/vaultwarden`` directory. Fetch and extract the binary from t
   [isabell@stardust vaultwarden]$
 
 Setup E-Mail for notifications.
-Use your favourite editor to create ``~/vaultwarden/output/.env`` with the following content:
+Use your favourite editor to create ``~/vaultwarden/.env`` with the following content:
 
 .. code-block:: ini
  :emphasize-lines: 1,2,5,6,7
@@ -127,6 +128,8 @@ Now it's time to test if everything works.
 
 .. code-block:: console
 
+ [isabell@stardust ~]$ export ENV_FILE=$HOME/vaultwarden.env
+ [isabell@stardust ~]$ export DATA_FOLDER=$HOME/vaultwarden/data
  [isabell@stardust ~]$ cd ~/vaultwarden/output
  [isabell@stardust output]$ ./vaultwarden
  /--------------------------------------------------------------------\
@@ -160,6 +163,7 @@ Use your favourite editor to create ``~/etc/services.d/vaultwarden.ini`` with th
   autostart=yes
   autorestart=yes
   startsecs=60
+  environment=ENV_FILE="%(ENV_HOME)s/vaultwarden/.env",DATA_FOLDER="%(ENV_HOME)s/vaultwarden/data"
 
 .. include:: includes/supervisord.rst
 
@@ -259,7 +263,6 @@ Updating vaultwarden is really easy.
   - Stop the server
   - Backup ``data`` and ``.env``
   - Pull latest image and extract binary
-  - Replace ``data`` and ``.env``
   - Start the server again
 
 To get the download link for the newest version of the web-vault look here web-vault-feed_.
@@ -270,18 +273,12 @@ To get the download link for the newest version of the web-vault look here web-v
  [isabell@stardust ~]$ cd ~/vaultwarden
  [isabell@stardust vaultwarden]$ supervisorctl stop vaultwarden
  vaultwarden: stopped
- [isabell@stardust vaultwarden]$ mkdir upgrade
- [isabell@stardust vaultwarden]$ cp output/data/ upgrade/. -r
- [isabell@stardust vaultwarden]$ cp output/.env upgrade/.
  [isabell@stardust vaultwarden]$ ./docker-image-extract vaultwarden/server:alpine
  Getting API token...
  Getting image manifest for vaultwarden/server:alpine...
  Fetching and extracting layer 97518928ae5f3d52d4164b314a7e73654eb686ecd8aafa0b79acd980773a740d...
  ...
  Image contents extracted into ./output.
- [isabell@stardust vaultwarden]$ cp upgrade/data/ output/. -r
- [isabell@stardust vaultwarden]$ cp upgrade/.env output/.
- [isabell@stardust vaultwarden]$ rm -rf upgrade
  [isabell@stardust vaultwarden]$ supervisorctl start vaultwarden
  vaultwarden: started
  [isabell@stardust vaultwarden]$


### PR DESCRIPTION
This PR moves both vaultwarden's `/data` directory as well as the `.env` file out of the `/output` dictionary, which gets overwritten with every update.

Therefore, one only has to stop vaultwarden, extract the latest update and is able to start it again.