### PR TITLE
[mattermost] Add automatic update script

### DIFF
--- a/source/guide_mattermost.rst
+++ b/source/guide_mattermost.rst
@@ -219,7 +219,7 @@ Use the script attached to update Mattermost to the current version. Run the scr
 
 	printf "Downloading Version v$version...\n"
 	mattermostfile="mattermost-$version-linux-amd64.tar.gz"
-	wget https://releases.mattermost.com/$1/$mattermostfile
+	wget https://releases.mattermost.com/${version}/$mattermostfile
 
 	printf "\nExtracting Version ..."
 	tar -xf $mattermostfile --transform='s,^[^/]\+,\0-upgrade,'

--- a/source/guide_mattermost.rst
+++ b/source/guide_mattermost.rst
@@ -177,6 +177,7 @@ Automatic Update
 Use the script attached to update Mattermost to the current version. Run the script above the mattermost-root directory.
 
 .. code-block:: shell
+
 	#!/bin/sh
 	printf "\n===\nWelcome to updating Mattermost... let us begin!\n===\n"
 

--- a/source/guide_mattermost.rst
+++ b/source/guide_mattermost.rst
@@ -203,7 +203,8 @@ Use the script attached to update Mattermost to the current version. Run the scr
 	then
 		printf "No manual version given. Check from official website ...\n"
 
-		version=$(curl -s https://api.github.com/repos/mattermost/mattermost-server/releases/latest | jq '.tag_name' | tail -c +3 | head -c -2)
+		tag_name=$(curl -s https://api.github.com/repos/mattermost/mattermost-server/releases/latest | jq --raw-output '.tag_name')
+		version=${TAG_NAME:1} # This will remove the first character `v` from the version tag `v1.2.3`
 
 		printf "Newest Version detected: v$version\n"
 	fi

--- a/source/guide_mattermost.rst
+++ b/source/guide_mattermost.rst
@@ -207,9 +207,14 @@ Use the script attached to update Mattermost to the current version. Run the scr
 		printf "Newest Version detected: v$version\n"
 	fi
 
-	printf "\n== Prepare for takeoff ==\n"
+	usedVersion=$(./mattermost/bin/mattermost version | grep -Po "(?<=Version: )([0-9]|\.)*(?=\s|$)")
+	if [ "$usedVersion" = "$version" ]
+	then
+		printf "\n=== You are up-to-date. No update needed. ===\n"
+		exit 0
+	fi
 
-	# TODO check if update is needed
+	printf "\n== Prepare for takeoff ==\n"
 
 	printf "Downloading Version v$version...\n"
 	mattermostfile="mattermost-$version-linux-amd64.tar.gz"

--- a/source/guide_mattermost.rst
+++ b/source/guide_mattermost.rst
@@ -204,7 +204,7 @@ Use the script attached to update Mattermost to the current version. Run the scr
 		printf "No manual version given. Check from official website ...\n"
 
 		tag_name=$(curl -s https://api.github.com/repos/mattermost/mattermost-server/releases/latest | jq --raw-output '.tag_name')
-		version=${TAG_NAME:1} # This will remove the first character `v` from the version tag `v1.2.3`
+		version=${tag_name:1} # This will remove the first character `v` from the version tag `v1.2.3`
 
 		printf "Newest Version detected: v$version\n"
 	fi


### PR DESCRIPTION
I wrote myself an update script for mattermost and wanted to share it with everyone.

Open:
- Get the latest version of mattermost via a feed, so the version input is not needed.

Tried:
- Reading latest version from website (very cumbersome, but might be possible)
- Read latest version from Github (needs Auth)
- No directory listing via https://releases.mattermost.com/
