### PR TITLE
[Nextcloud] some simple reworks

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -342,13 +342,14 @@ Nextcloud Talk
 ^^^^^^^^^^^^^^
 
 To enable video/audio calls in your instance, install and enable the "Talk" app in the admin interface.
-If the web installation fails, install the app manually in your shell:
+If the web installation fails, install the app manually in your shell. Note that the Talk app's technical name is actually spreed.
 
 .. code-block:: console
 
-  [isabell@stardust html]$ cd apps
-  [isabell@stardust apps]$ curl -L https://github.com/nextcloud/spreed/releases/download/v8.0.7/spreed-8.0.7.tar.gz | tar -xvzf -
-  [isabell@stardust apps]$
+  [isabell@stardust html]$ php ~/html/occ app:install spreed
+  spreed 16.0.0 installed
+  spreed enabled
+  [isabell@stardust html]$
 
 Reload the page and press the talk icon in the top menu bar.
 


### PR DESCRIPTION
## docs links

The link structure for the docs has changed.
See the overview at
https://docs.nextcloud.com/

`latest` -> `upcoming` (not released)
`stable` -> `latest stable`

- [x] the online stable documentation currently is ~not~ up to date, ~so I keep this PR on draft for now~
  edit: they updated their docs
  ~as actually~ the support for PHP 7.2 is dropped and PHP 8.2 is added, see ⬇️
  https://github.com/nextcloud/documentation/blob/stable26/admin_manual/installation/system_requirements.rst
  https://docs.nextcloud.com/server/stable/admin_manual/installation/system_requirements.html

## app install via CLI

The manual install via direct download is more complex and uses a very outdated version/link