### PR TITLE
[privatebin] enhance guide

### DIFF
--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -161,7 +161,7 @@ Of course also adjust the file if you already use a robots.txt.
 Making your PrivateBin instance read-only
 -----------------------------------------
 
-If you want to limit write access to your PrivateBin instance, i.e. specify who can create content, you can configure the ``.htaccess`` file accordingly.
+If you want to limit write access to your PrivateBin instance, i.e. specify who can paste data, you can configure the ``.htaccess`` file accordingly.
 Choose a username that should have write access and provide it to the ``htpasswd`` command:
 
 .. code-block:: console

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -174,6 +174,7 @@ Choose a username that should have write access and provide it to the ``htpasswd
  [isabell@stardust html]$
  
 Further users can be added by omitting the ``-c`` flag:
+
 .. code-block:: console
  
  [isabell@stardust html]$ htpasswd .htpasswd another-user

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -158,7 +158,7 @@ If you followed this guide, it is already at the right place in your :manual:`Do
 However, if you installed PrivateBin into a subdirectory, you have to move ``robots.txt`` back into the DocumentRoot.
 Of course also adjust the file if you already use a robots.txt.
 
-Making your PrivateBin instance read-only
+Making your PrivateBin Instance read-only
 -----------------------------------------
 
 If you want to limit write access to your PrivateBin instance, i.e. specify who can paste data, you can configure the ``.htaccess`` file accordingly.
@@ -228,7 +228,7 @@ The .htaccess file should look like this:
  php_value max_file_uploads 100
  </IfModule>
 
-The PrivateBin site is still visible to the public
+The PrivateBin site is still visible to the public. 
 When a user tries to publish content, a Basic-Auth popup will ask for username and password.
 The generated links are accessible to everyone.
 
@@ -238,7 +238,17 @@ Updates
 
 .. note:: Check the update feed_ regularly to stay informed about the latest version.
 
-Updating is quite easy. Just repeat all steps of the :lab_anchor:`Installation chapter <guide_privatebin.html#installation>`.
+Backup your config.
+
+.. code-block:: console
+
+ [isabell@stardust ~]$ cd ~/html
+ [isabell@stardust html]$ cp -p .htaccess .htaccess.backup
+ [isabell@stardust html]$ cp -p .htpasswd .htpasswd.backup
+ [isabell@stardust html]$ cp -rp ~/privatebin-data/ ~/privatebin-data-backup
+ [isabell@stardust html]$ 
+
+Then repeat the steps of the :lab_anchor:`Installation chapter <guide_privatebin.html#installation>`.
 Your configuration file won't get overwritten.
 
 Check the Release-Notes if the configuration changed between ``cfg/conf.sample.php`` and your ``conf.php``.

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -1,7 +1,7 @@
 .. highlight:: console
 
 .. author:: Nepomacs <https://github.com/Nepomacs/>
-.. author:: <https://franok.de>
+.. author:: franok <https://franok.de>
 
 .. categorize your guide! refer to the current list of tags: https://lab.uberspace.de/tags
 .. tag:: privacy
@@ -113,7 +113,7 @@ If not already there, go to the ``html`` directory before running ``mv``.
 Changing index.php
 ------------------
 
-Now edit ``~/html/index.php``  to inform PrivateBin about to the new location of the folders.
+Now edit ``~/html/index.php``  to inform PrivateBin about the new location of the folders.
 
 .. code-block:: php
 
@@ -158,11 +158,11 @@ If you followed this guide, it is already at the right place in your :manual:`Do
 However, if you installed PrivateBin into a subdirectory, you have to move ``robots.txt`` back into the DocumentRoot.
 Of course also adjust the file if you already use a robots.txt.
 
-Making your pastebin read-only
-------------------------------
+Making your PrivateBin instance read-only
+-----------------------------------------
 
-If you want to limit who has write access to your PrivateBin instance, i.e. who can create content, you can configure the .htaccess file accordingly.
-Choose a username that should have write access and provide it to the htpasswd command:
+If you want to limit write access to your PrivateBin instance, i.e. specify who can create content, you can configure the ``.htaccess`` file accordingly.
+Choose a username that should have write access and provide it to the ``htpasswd`` command:
 
 .. code-block:: console
 
@@ -173,7 +173,16 @@ Choose a username that should have write access and provide it to the htpasswd c
  Adding password for user sample_user
  [isabell@stardust html]$
  
-Edit the .htaccess file and add the following lines:
+Further users can be added by omitting the ``-c`` flag:
+.. code-block:: console
+ 
+ [isabell@stardust html]$ htpasswd .htpasswd another-user
+ New password:
+ Re-type new password:
+ Adding password for user another-user
+ [isabell@stardust html]$
+ 
+Edit the ``.htaccess`` file and add the following lines (exchange ``isabell`` by your username):
 
 .. code-block:: text
 
@@ -194,6 +203,7 @@ Edit the .htaccess file and add the following lines:
  [isabell@stardust html]$
 
 The .htaccess file should look like this:
+
 .. code-block::
 
  [isabell@stardust html]$ cat .htaccess
@@ -217,14 +227,15 @@ The .htaccess file should look like this:
  php_value max_file_uploads 100
  </IfModule>
 
-The PrivateBin site is still visible to the public, but when a user tries to publish content, a Basic Auth popup will ask for username and password.
-The generated links are still accessible to everyone.
+The PrivateBin site is still visible to the public
+When a user tries to publish content, a Basic-Auth popup will ask for username and password.
+The generated links are accessible to everyone.
 
 
 Updates
 =======
 
-.. note:: Check the update feed_ regularly to stay informed about the newest version.
+.. note:: Check the update feed_ regularly to stay informed about the latest version.
 
 Updating is quite easy. Just repeat all steps of the :lab_anchor:`Installation chapter <guide_privatebin.html#installation>`.
 Your configuration file won't get overwritten.
@@ -242,6 +253,6 @@ Also check ``.htaccess.disabled`` if further adjustments needed to be made.
 
 ----
 
-Tested with PrivateBin 1.5.0, Uberspace 7.13, PHP 8.1
+Tested with PrivateBin 1.5.1, Uberspace 7.15.1, PHP 8.1
 
 .. author_list::

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -197,7 +197,7 @@ Edit the ``.htaccess`` file and add the following lines (exchange ``isabell`` by
     Require valid-user
  </LimitExcept>
 
-The ``.htaccess`` file should look like this:
+The ``.htaccess`` file should look similar to this example:
 
 .. code-block:: console
  :emphasize-lines: 7-12

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -161,7 +161,10 @@ Of course also adjust the file if you already use a robots.txt.
 Making your PrivateBin Instance read-only
 -----------------------------------------
 
-If you want to limit write access to your PrivateBin instance, i.e. specify who can paste data, you can configure the ``.htaccess`` file accordingly.
+This section will teach you how you can limit write access to your PrivateBin instance, i.e. specify who can paste data.
+
+While PrivateBin does not have a concept of access control in itself, `the documentation suggests different ways <https://github.com/PrivateBin/PrivateBin/wiki/FAQ#how-can-i-link-to-a-read-only-mode-where-users-cant-submit-pastes>`_ in which a read-only mode can be achieved using some custom configuration. In this guide we will implement the second method that will require basic authentication for POST requests.
+
 Choose a username that should have write access and provide it to the ``htpasswd`` command:
 
 .. code-block:: console
@@ -183,7 +186,7 @@ Further users can be added by omitting the ``-c`` flag:
  Adding password for user another-user
  [isabell@stardust html]$
  
-Edit the ``.htaccess`` file and add the following lines (exchange ``isabell`` by your username):
+Edit the ``.htaccess`` file and add the following lines (exchange ``isabell`` by your uberspace username):
 
 .. code-block:: text
 
@@ -194,18 +197,10 @@ Edit the ``.htaccess`` file and add the following lines (exchange ``isabell`` by
     Require valid-user
  </LimitExcept>
 
+The ``.htaccess`` file should look like this:
+
 .. code-block:: console
-
- [isabell@stardust ~]$ cd ~/html
- [isabell@stardust html]$ htpasswd -c .htpasswd sample_user
- New password:
- Re-type new password:
- Adding password for user sample_user
- [isabell@stardust html]$
-
-The .htaccess file should look like this:
-
-.. code-block::
+ :emphasize-lines: 7-12
 
  [isabell@stardust html]$ cat .htaccess
  RewriteEngine on
@@ -229,7 +224,7 @@ The .htaccess file should look like this:
  </IfModule>
 
 The PrivateBin site is still visible to the public. 
-When a user tries to publish content, a Basic-Auth popup will ask for username and password.
+When a user tries to publish content in your pastebin, a Basic-Auth popup will ask for username and password.
 The generated links are accessible to everyone.
 
 
@@ -238,7 +233,7 @@ Updates
 
 .. note:: Check the update feed_ regularly to stay informed about the latest version.
 
-Backup your config.
+Backup your config:
 
 .. code-block:: console
 

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -82,8 +82,8 @@ Untar the archive and then delete it.
 .. code-block:: console
  :emphasize-lines: 1,2
 
- [isabell@stardust html]$ tar -xzf PrivateBin-1.5.1.tar.gz --strip-components=1
- [isabell@stardust html]$ rm PrivateBin-1.5.1.tar.gz
+ [isabell@stardust html]$ tar -xzf PrivateBin-$PBIN_VERSION.tar.gz --strip-components=1
+ [isabell@stardust html]$ rm PrivateBin-$PBIN_VERSION.tar.gz
  [isabell@stardust html]$
 
 
@@ -214,14 +214,6 @@ The ``.htaccess`` file should look similar to this example:
  <LimitExcept GET>
     Require valid-user
  </LimitExcept>
- 
- <IfModule mod_php7.c>
- php_value max_execution_time 30
- php_value post_max_size 10M
- php_value upload_max_size 10M
- php_value upload_max_filesize 10M
- php_value max_file_uploads 100
- </IfModule>
 
 The PrivateBin site is still visible to the public. 
 When a user tries to publish content in your pastebin, a Basic-Auth popup will ask for username and password.

--- a/source/guide_privatebin.rst
+++ b/source/guide_privatebin.rst
@@ -106,8 +106,8 @@ If not already there, go to the ``html`` directory before running ``mv``.
 .. code-block:: console
 
  [isabell@stardust ~]$ cd ~/html
- [isabell@stardust html]$ mkdir /home/$USER/privatebin-data
- [isabell@stardust html]$ mv -t /home/$USER/privatebin-data cfg/ lib/ tpl/ vendor/
+ [isabell@stardust html]$ mkdir ~/privatebin-data
+ [isabell@stardust html]$ mv -t ~/privatebin-data cfg/ lib/ tpl/ vendor/
  [isabell@stardust html]$
 
 Changing index.php
@@ -134,7 +134,7 @@ You can find an example configuration file at ``cfg/conf.sample.php`` with the d
 
 .. code-block:: console
 
- [isabell@stardust ~]$ cd /home/$USER/privatebin-data
+ [isabell@stardust ~]$ cd ~/privatebin-data
  [isabell@stardust html]$ cp cfg/conf.sample.php cfg/conf.php
  [isabell@stardust html]$
 


### PR DESCRIPTION
Enhance guide by instructions for read-only access for non-authenticated users using Basic Auth restriction for POST requests in .htaccess file.

I successfully implemented [a "read-only" restriction](https://github.com/PrivateBin/PrivateBin/wiki/FAQ#how-can-i-link-to-a-read-only-mode-where-users-cant-submit-pastes) on my instance of PrivateBin and would like to share my knowledge in the lab guide.