### PR TITLE
Update guide_isso.rst

### DIFF
--- a/source/guide_isso.rst
+++ b/source/guide_isso.rst
@@ -18,7 +18,7 @@ Isso
 
 .. tag_list::
 
-Isso_ is a simple, self-hosted commenting server which can easily be included inside blogging platforms such as :lab:`Ghost <guide_ghost>` or :lab:`Wordpress <guide_wordpress>`.
+Isso_ is a simple, self-hosted commenting server which can easily be included inside blogging platforms such as :lab:`Wordpress <guide_wordpress>`.
 
 Users can format comments by using Markdown. Isso has spam protection and an admin panel to administrate comments.
 


### PR DESCRIPTION
Ghost is not supported on Uberspace anymore and the page to the lab is non existent.