### PR TITLE
forgejo: convert markdown link to RST

### DIFF
--- a/source/guide_forgejo.rst
+++ b/source/guide_forgejo.rst
@@ -45,7 +45,7 @@ We need a database:
   [isabell@stardust ~]$ mysql --execute "CREATE DATABASE ${USER}_forgejo"
   [isabell@stardust ~]$
 
-We can use the uberspace or [your own domain](https://manual.uberspace.de/web-domains/#setup):
+We can use the uberspace or `your own domain <https://manual.uberspace.de/web-domains/#setup>`_:
 
 .. include:: includes/web-domain-list.rst
 


### PR DESCRIPTION
The current compiled output is broken on https://lab.uberspace.de/guide_forgejo/, this small fix should solve the issue.