### PR TITLE
[Gitea] update the update script

### DIFF
--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -60,7 +60,7 @@ Check current version of Gitea at releases_ page:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ VERSION=1.17.2
+  [isabell@stardust ~]$ VERSION=1.19.2
   [isabell@stardust ~]$ mkdir ~/gitea
   [isabell@stardust ~]$ wget -O ~/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64
   [...]
@@ -526,6 +526,6 @@ Now we have to append the config file ``~/gitea/custom/conf/app.ini`` with:
 
 ----
 
-Tested with Gitea 1.17.2, Uberspace 7.13.0
+Tested with Gitea 1.19.2, Uberspace 7.15.1
 
 .. author_list::

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -60,7 +60,7 @@ Check current version of Gitea at releases_ page:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ VERSION=1.19.2
+  [isabell@stardust ~]$ VERSION=1.19.3
   [isabell@stardust ~]$ mkdir ~/gitea
   [isabell@stardust ~]$ wget -O ~/gitea/gitea https://github.com/go-gitea/gitea/releases/download/v${VERSION}/gitea-${VERSION}-linux-amd64
   [...]
@@ -529,6 +529,6 @@ Now we have to append the config file ``~/gitea/custom/conf/app.ini`` with:
 
 ----
 
-Tested with Gitea 1.19.2, Uberspace 7.15.1
+Tested with Gitea 1.19.3, Uberspace 7.15.1
 
 .. author_list::

--- a/source/guide_gitea.rst
+++ b/source/guide_gitea.rst
@@ -168,6 +168,9 @@ Create a config file ``~/gitea/custom/conf/app.ini`` with the content of the fol
   MAILER_TYPE = sendmail
   FROM        = isabell@uber.space
 
+  [other]
+  SHOW_FOOTER_VERSION = false ; hide version number from strangers - you can still see it in the admin panel at /admin
+
 .. note::
 
   This config block contains a secure and convenient basic configuration. You may change it depending on your needs and knowledge.


### PR DESCRIPTION
## config

- hide version number, so this info is only visable at `/admin` or via CLI
  ![grafik](https://user-images.githubusercontent.com/8345730/235127164-7ccad50c-b121-4af2-a648-72984f729c5f.png)

## update script changes

- I refactored a few things,
- removed some checks (they were actually added for debug reasons) as the issues should be fixed by the `fix_stop_signal` function,
- fixed a bug in the version comparator so it is not a tautology
- ignore versions with pre-release code words,
  this is maybe important for Forgejo, but it looks like they now publish their pre-releases in another [repository](https://codeberg.org/forgejo-experimental/forgejo/releases),
   so maybe a slightly changed version of this script (API requests) can be used for Forgejo,
- handle expired PGP keys

## [deploy preview 👀](https://deploy-preview-1522--uberlab.netlify.app/guide_gitea/)