### PR TITLE
Update guide_vaultwarden.rst

### DIFF
--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -283,6 +283,11 @@ Updating vaultwarden is really easy.
  [isabell@stardust vaultwarden]$ supervisorctl start vaultwarden
  vaultwarden: started
  [isabell@stardust vaultwarden]$
+ 
+Hint: If the update fails
+-------------------------
+
+When you get the error message ``No layers returned. Verify that the image and tag are valid.`` you'll have to update the Docker Image Extractor first.
 
 Acknowledgements
 ================


### PR DESCRIPTION
Upgrading the application can fail, if the Docker Image Extractor is to old. Added a hint for this.