### PR TITLE
[Nextcloud] add `occ upgrade` command for app updates

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -374,7 +374,7 @@ Create ``~/bin/nextcloud-update`` with the following content:
  ## Use the Uberspace backup system for files and database if you need to roll back.
  ## The Nextcloud updater creates backups only to safe base and app code data and config files
  ## so it takes ressources you might need for your productive data.
- ## Deactivate NC-updater Backups with --no-backup (works from 19.0.4, 18.0.10 and 17.0.10)
+ ## Deactivate NC-updater Backups with --no-backup
  php ~/html/updater/updater.phar -vv --no-backup --no-interaction
 
  ## database optimisations
@@ -384,6 +384,8 @@ Create ``~/bin/nextcloud-update`` with the following content:
  php ~/html/occ db:convert-filecache-bigint --no-interaction
 
  php ~/html/occ app:update --all
+ ## App updates may require additional steps to be done by the `upgrade` command
+ php ~/html/occ upgrade
  /usr/sbin/restorecon -R ~/html
 
  ## FYI: If that file exist...


### PR DESCRIPTION
App updates may require additional steps to be done by the `occ upgrade` command.

Usually you would notice this by being redirected to an upgrade page in your browser.

So this should fix it:
![app-update](https://github.com/Uberspace/lab/assets/8345730/29dadd8f-1ca4-43ff-8884-722b07b35b6d)
