### PR TITLE
[HedgeDoc] use Node.js 20

### DIFF
--- a/source/guide_hedgedoc.rst
+++ b/source/guide_hedgedoc.rst
@@ -41,8 +41,8 @@ Use the recommended :manual:`Node.js <lang-nodejs>` version as mentioned in the 
 
 ::
 
-  [isabell@stardust ~]$ uberspace tools version use node 16
-  Selected Node.js version 16
+  [isabell@stardust ~]$ uberspace tools version use node 20
+  Selected Node.js version 20
   The new configuration is adapted immediately. Minor updates will be applied automatically.
   [isabell@stardust ~]$
 
@@ -62,7 +62,7 @@ Check whether the marked line is the latest_ release.
 .. code-block:: console
   :emphasize-lines: 1
 
-  [isabell@stardust ~]$ VERSION=1.9.2
+  [isabell@stardust ~]$ VERSION=1.9.8
   [isabell@stardust ~]$ wget https://github.com/hedgedoc/hedgedoc/releases/download/$VERSION/hedgedoc-$VERSION.tar.gz
   [...]
   100%[======================================================>] 50,784,713  16.8MB/s   in 2.9s
@@ -382,6 +382,6 @@ You can run this script with:
 
 ----
 
-Tested with HedgeDoc 1.9.2, Uberspace 7.11.5
+Tested with HedgeDoc 1.9.8, Node.js 20, Uberspace 7.15.2
 
 .. author_list::


### PR DESCRIPTION
> We recommend to use the latest LTS release of Node.js.

[tested versions](https://github.com/hedgedoc/hedgedoc/blob/1.9.8/.github/workflows/build-and-test.yml)
```yml
[...]
strategy:
      matrix:
        node: ['16', '18', '20']
[...]
```

<details>
 <summary>clean manual install log 1.9.8</summary>
 
The app seems to work like expected via browser
```console
[test123@alpheca ~]$ uberspace tools version use node 20
Selected Node.js version 20
The new configuration is adapted immediately. Minor updates will be applied automatically.

[test123@alpheca ~]$ my_print_defaults client
--default-character-set=utf8mb4
--user=test123
--password=verysecrethaha
[test123@alpheca ~]$ VERSION=1.9.8
[test123@alpheca ~]$ wget https://github.com/hedgedoc/hedgedoc/releases/download/$VERSION/hedgedoc-$VERSION.tar.gz
--2023-06-14 13:36:21--  https://github.com/hedgedoc/hedgedoc/releases/download/1.9.8/hedgedoc-1.9.8.tar.gz
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://objects.githubusercontent.com/github-production-release-asset-2e65be/177987738/db930e7c-26b7-4337-9bbe-30a2ae0f0176?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230614%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230614T113621Z&X-Amz-Expires=300&X-Amz-Signature=265590f7532ea478497b95158f22ee20df098d031f2e1e9c74cf47b715e4a66f&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=177987738&response-content-disposition=attachment%3B%20filename%3Dhedgedoc-1.9.8.tar.gz&response-content-type=application%2Foctet-stream [following]
--2023-06-14 13:36:21--  https://objects.githubusercontent.com/github-production-release-asset-2e65be/177987738/db930e7c-26b7-4337-9bbe-30a2ae0f0176?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20230614%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230614T113621Z&X-Amz-Expires=300&X-Amz-Signature=265590f7532ea478497b95158f22ee20df098d031f2e1e9c74cf47b715e4a66f&X-Amz-SignedHeaders=host&actor_id=0&key_id=0&repo_id=177987738&response-content-disposition=attachment%3B%20filename%3Dhedgedoc-1.9.8.tar.gz&response-content-type=application%2Foctet-stream
Resolving objects.githubusercontent.com (objects.githubusercontent.com)... 185.199.108.133, 185.199.109.133, 185.199.110.133, ...
Connecting to objects.githubusercontent.com (objects.githubusercontent.com)|185.199.108.133|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 62250345 (59M) [application/octet-stream]
Saving to: 'hedgedoc-1.9.8.tar.gz'

100%[==============================================================================>] 62,250,345  51.5MB/s   in 1.2s

2023-06-14 13:36:23 (51.5 MB/s) - 'hedgedoc-1.9.8.tar.gz' saved [62250345/62250345]

[test123@alpheca ~]$ tar --extract --gzip --file=hedgedoc-$VERSION.tar.gz
[test123@alpheca ~]$ rm --verbose hedgedoc-$VERSION.tar.gz
removed 'hedgedoc-1.9.8.tar.gz'
[test123@alpheca ~]$ cd hedgedoc
[test123@alpheca hedgedoc]$ bin/setup
Copying config files...
Installing packages...
➤ YN0000: ┌ Resolution step
➤ YN0060: │ HedgeDoc@workspace:. provides sequelize (p91ea1) with version 5.22.5, which doesn't satisfy what connect-session-sequelize requests
➤ YN0002: │ HedgeDoc@workspace:. doesn't provide webpack (p83411), requested by clean-webpack-plugin
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed in 0s 390ms
➤ YN0000: ┌ Fetch step
➤ YN0013: │ xtend@npm:4.0.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ xtraverse@npm:0.1.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yallist@npm:4.0.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ yeast@npm:0.1.2 can't be found in the cache and will be fetched from the remote registry
➤ YN0013: │ zip-stream@npm:4.1.0 can't be found in the cache and will be fetched from the remote registry
➤ YN0000: └ Completed in 47s 337ms
➤ YN0000: ┌ Link step
➤ YN0007: │ bufferutil@npm:4.0.7 must be built because it never has been before or the last one failed
➤ YN0007: │ utf-8-validate@npm:6.0.3 must be built because it never has been before or the last one failed
➤ YN0007: │ sqlite3@npm:5.1.6 [77177] must be built because it never has been before or the last one failed
➤ YN0000: └ Completed in 23s 340ms
➤ YN0000: Done with warnings in 1m 12s
If you want to build the frontend yourself, you need to run 'yarn install --immutable' before 'yarn build' to install the devDependencies for the build process.

Edit the following config file to setup HedgeDoc server and client.
Read more info at https://docs.hedgedoc.org/configuration/

* config.json           -- HedgeDoc config
[test123@alpheca hedgedoc]$ mkdir --verbose ~/hedgedoc_uploads
mkdir: created directory '/home/test123/hedgedoc_uploads'
[test123@alpheca hedgedoc]$ mysql --verbose --execute="CREATE DATABASE ${USER}_hedgedoc"
--------------
CREATE DATABASE test123_hedgedoc
--------------

[test123@alpheca hedgedoc]$ nano ~/hedgedoc/config.json
[test123@alpheca hedgedoc]$ echo "" > ~/hedgedoc/config.json
[test123@alpheca hedgedoc]$ nano ~/hedgedoc/config.json
[test123@alpheca hedgedoc]$ nano ~/hedgedoc/config.json
[test123@alpheca hedgedoc]$ pwgen 32 1
hel8voh2lalalalablaaaaaaaaaaaaaaaaa
[test123@alpheca hedgedoc]$ nano ~/etc/services.d/hedgedoc.ini
[test123@alpheca hedgedoc]$ nano ~/etc/services.d/hedgedoc.ini
[test123@alpheca hedgedoc]$ supervisorctl reread
hedgedoc: available
[test123@alpheca hedgedoc]$ supervisorctl update
hedgedoc: added process group
[test123@alpheca hedgedoc]$ supervisorctl status
hedgedoc                         STARTING
[test123@alpheca hedgedoc]$ supervisorctl tail -f hedgedoc
Warning: sys.stdout.encoding is set to ANSI_X3.4-1968, so Unicode output may fail. Check your LANG and PYTHONIOENCODING environment settings.
==> Press Ctrl-C to exit <==
fo:     == 20180306150303-fix-enum: migrated (0.104s)

2023-06-14T11:44:08.072Z info:  == 20180326103000-use-text-in-tokens: migrating =======
2023-06-14T11:44:08.234Z info:  == 20180326103000-use-text-in-tokens: migrated (0.161s)

2023-06-14T11:44:08.246Z info:  == 20180525153000-user-add-delete-token: migrating =======
2023-06-14T11:44:08.314Z info:  == 20180525153000-user-add-delete-token: migrated (0.067s)

2023-06-14T11:44:08.325Z info:  == 20200321153000-fix-account-deletion: migrating =======
2023-06-14T11:44:08.329Z info:  Cleaning up notes that should already have been removed. Sorry.
2023-06-14T11:44:08.707Z info:  == 20200321153000-fix-account-deletion: migrated (0.382s)

2023-06-14T11:44:08.718Z info:  == 20220901102800-convert-history-to-longtext: migrating =======
2023-06-14T11:44:08.799Z info:  == 20220901102800-convert-history-to-longtext: migrated (0.080s)

2023-06-14T11:44:08.800Z info:  All migrations performed successfully
2023-06-14T11:44:08.881Z info:  HTTP Server listening at 0.0.0.0:3000
^C
[test123@alpheca hedgedoc]$ uberspace web backend set / --http --port 3000
Set backend for / to port 3000; please make sure something is listening!
You can always check the status of your backend using "uberspace web backend list".
[test123@alpheca hedgedoc]$ NODE_ENV=production bin/manage_users --add test123@uber.space
Password for test123@uber.space:********
Created user with email test123@uber.space
[test123@alpheca hedgedoc]$
```
</details>