### PR TITLE
Update guide_postgresql.rst

### DIFF
--- a/source/guide_postgresql.rst
+++ b/source/guide_postgresql.rst
@@ -120,6 +120,8 @@ We now use the temporary password file ``~/pgpass.temp`` (containing only your p
 .. code-block:: console
     :emphasize-lines: 1
 
+    [isabell@stardust ~]$ export LC_CTYPE="de_DE.UTF-8"
+    [isabell@stardust ~]$ export LC_ALL="de_DE.UTF-8"
     [isabell@stardust ~]$ initdb --pwfile ~/pgpass.temp --auth=scram-sha-256 -E UTF8 -D ~/opt/postgresql/data/
     The files belonging to this database system will be owned by user "isabell".
     This user must also own the server process.

--- a/source/guide_postgresql.rst
+++ b/source/guide_postgresql.rst
@@ -120,8 +120,8 @@ We now use the temporary password file ``~/pgpass.temp`` (containing only your p
 .. code-block:: console
     :emphasize-lines: 1
 
-    [isabell@stardust ~]$ export LC_CTYPE="de_DE.UTF-8"
-    [isabell@stardust ~]$ export LC_ALL="de_DE.UTF-8"
+    [isabell@stardust ~]$ export LC_CTYPE="en_US.UTF-8"
+    [isabell@stardust ~]$ export LC_ALL="en_US.UTF-8"
     [isabell@stardust ~]$ initdb --pwfile ~/pgpass.temp --auth=scram-sha-256 -E UTF8 -D ~/opt/postgresql/data/
     The files belonging to this database system will be owned by user "isabell".
     This user must also own the server process.


### PR DESCRIPTION
Add export LC_ALL and LC_TYPE to prevent error 

> initdb --pwfile ~/pgpass.temp --auth=scram-sha-256 -E UTF8 -D ~/opt/postgresql/data/
> The files belonging to this database system will be owned by user "nas".
> This user must also own the server process.
>
> initdb: error: invalid locale settings; check LANG and LC_* environment variables