### PR TITLE
Update guide_antragsgruen.rst

### DIFF
--- a/source/guide_antragsgruen.rst
+++ b/source/guide_antragsgruen.rst
@@ -89,8 +89,7 @@ You can now head over to your ``https://USER.uber.space`` web site and complete 
 Updates
 =======
 
-Use the built-in `web updater`_. When you're applying several updates at once (e.g. because of updating from v4.9.1 to v4.12.0, via v4.10.0,  v4.10.1
- etc.), don't forget to execute the database migration after every single update step, not only once after all the file updates are completed. Otherwise you might run into database errors.
+Use the built-in `web updater`_. When you're applying several updates at once (e.g. because of updating from v4.9.1 to v4.12.0, via v4.10.0,  v4.10.1 etc.), don't forget to execute the database migration after every single update step, not only once after all the file updates are completed. Otherwise you might run into database errors.
 
 
 .. _Antragsgrün: https://antragsgruen.de/
@@ -102,6 +101,6 @@ Use the built-in `web updater`_. When you're applying several updates at once (e
 ----
 
 
-Tested with Antragsgrün 4.10.1, Uberspace 7.13.0, and PHP 8.1
+Tested with Antragsgrün 4.12.0, Uberspace 7.13.0, and PHP 8.1
 
 .. author_list::

--- a/source/guide_antragsgruen.rst
+++ b/source/guide_antragsgruen.rst
@@ -46,16 +46,18 @@ Your domain should be set up:
 Installation
 ============
 
+Unfortunately, the Antragsgrün web installer `doesn't work anymore`_ on uberspace since v4.9.1. However, you can install that version and use the built-in web updater (see below) to upgrade to the latest version.
+
 Downloading
 -----------
 
-Get the link to the `latest Antragsgrün release`_ ``.tar.bz2`` release archive, then ``cd`` to your :manual:`document root <web-documentroot>`, download the archive and extract it on the fly, omitting the top-level directory from the archive:
+Download the `v4.9.1 Antragsgrün release`_ ``.tar.bz2`` archive, then ``cd`` to your :manual:`document root <web-documentroot>`, download the archive and extract it on the fly, omitting the top-level directory from the archive:
 
 .. code-block:: console
 
  [isabell@stardust ~]$ cd html
  [isabell@stardust html]$ rm nocontent.html
- [isabell@stardust html]$ curl -L https://github.com/CatoTH/antragsgruen/releases/download/v4.8.1/antragsgruen-4.8.1.tar.bz2 | tar -xjf - --strip-components=1
+ [isabell@stardust html]$ curl -L https://github.com/CatoTH/antragsgruen/releases/download/v4.9.1/antragsgruen-4.9.1.tar.bz2 | tar -xjf - --strip-components=1
    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                   Dload  Upload   Total   Spent    Left  Speed
  100   661  100   661    0     0   2980      0 --:--:-- --:--:-- --:--:--  2990
@@ -87,13 +89,15 @@ You can now head over to your ``https://USER.uber.space`` web site and complete 
 Updates
 =======
 
-Use the built-in `web updater`_.
+Use the built-in `web updater`_. When you're applying several updates at once (e.g. because of updating from v4.9.1 to v4.12.0, via v4.10.0,  v4.10.1
+ etc.), don't forget to execute the database migration after every single update step, not only once after all the file updates are completed. Otherwise you might run into database errors.
 
 
 .. _Antragsgrün: https://antragsgruen.de/
 .. _`system requirements`: https://github.com/CatoTH/antragsgruen#requirements
-.. _`latest Antragsgrün release`: https://github.com/CatoTH/antragsgruen/releases/latest
+.. _`v4.9.1 Antragsgrün release`: https://github.com/CatoTH/antragsgruen/releases/tag/v4.9.1
 .. _`web updater`: https://github.com/CatoTH/antragsgruen#using-the-web-based-updater
+.. _`doesn't work anymore`: https://github.com/CatoTH/antragsgruen/issues/827
 
 ----
 


### PR DESCRIPTION
The Antragsgrün web installer doesn't work anymore, as described here (https://github.com/Uberspace/lab/issues/1127#issuecomment-1683566695) and here (https://github.com/CatoTH/antragsgruen/issues/827). This change explains an easy workaround to get the latest version running.