### PR TITLE
Update guide_ejabberd.rst: added module location

### DIFF
--- a/source/guide_ejabberd.rst
+++ b/source/guide_ejabberd.rst
@@ -62,6 +62,7 @@ The files will be installed to the following locations:
 
   * ``~/sbin/``: executables (``ejabberdctl``)
   * ``~/etc/ejabberd/``: configuration files (mainly ``ejabberd.yml``)
+  * ``~/lib/``: compiled ejabberd modules
   * ``~/var/lib/ejabberd/``: runtime files including internal mnesia database
   * ``~/var/log/ejabberd/``: logfiles
 


### PR DESCRIPTION
I just checked my installation and found the missing module location. This is important during updates, because sometimes new files won't override the existing ones.