### PR TITLE
updated magicmirror guide to current verified versions

### DIFF
--- a/source/guide_magicmirror.rst
+++ b/source/guide_magicmirror.rst
@@ -38,7 +38,7 @@ We're using :manual:`Node.js <lang-nodejs>` in the latest version:
 .. code-block:: console
 
  [isabell@stardust ~]$ uberspace tools version show node
- Using 'Node.js' version: '14'
+ Using 'Node.js' version: '20'
  [isabell@stardust ~]$
 
 Your website domain needs to be set up:
@@ -115,6 +115,6 @@ Stop your service and repeat the installation step.
 
 ----
 
-Tested with MagicMirror² v2.14.0 and Uberspace 7.10.0
+Tested with MagicMirror² v2.25.0 and Uberspace 7.15.6
 
 .. author_list::


### PR DESCRIPTION
The guide works with current Nodejs versions.

Adapted version numbers in the guide to reflect this.

Closes #1603