### PR TITLE
Update guide_mailman-3.rst to Python 3.9

### DIFF
--- a/source/guide_mailman-3.rst
+++ b/source/guide_mailman-3.rst
@@ -70,7 +70,7 @@ Install Mailman 3 and its dependencies via pip.
 
 ::
 
- [isabell@stardust ~]$ pip3.8 install --user mailman hyperkitty postorius mailman-hyperkitty whoosh
+ [isabell@stardust ~]$ pip3.9 install --user mailman hyperkitty postorius mailman-hyperkitty whoosh
  [...]
  [isabell@stardust ~]$
 
@@ -80,7 +80,7 @@ we have to pin some package versions:
 
 ::
 
- [isabell@stardust ~]$ pip3.8 install --user "urllib3<2" "flufl.lock<8" "flufl.i18n<5" "importlib_resources<6.0"
+ [isabell@stardust ~]$ pip3.9 install --user "urllib3<2" "flufl.lock<8" "flufl.i18n<5" "importlib_resources<6.0"
  [...]
  [isabell@stardust ~]$
 
@@ -116,7 +116,7 @@ Install the required uwsgi package with pip.
 
 ::
 
- [isabell@stardust ~]$ pip3.8 install uwsgi --user
+ [isabell@stardust ~]$ pip3.9 install uwsgi --user
  [isabell@stardust ~]$
 
 After that, continue with setting it up as a service.
@@ -344,9 +344,9 @@ After we have adjusted our configuration file, we need to compile and configure 
 
  .. code :: bash
 
-  [isabell@stardust ~]$ pip3.8 install --user pysqlite3-binary
+  [isabell@stardust ~]$ pip3.9 install --user pysqlite3-binary
   [...]
-  [isabell@stardust ~]$ ln -s pysqlite3 ~/.local/lib/python3.8/site-packages/sqlite3
+  [isabell@stardust ~]$ ln -s pysqlite3 ~/.local/lib/python3.9/site-packages/sqlite3
   [isabell@stardust ~]$
 
  Now add this ``~/mailman-suite/settings.py`` in order to have use that version of the ``sqlite3`` instead of the built-in one.
@@ -354,16 +354,16 @@ After we have adjusted our configuration file, we need to compile and configure 
  .. code :: python
 
   import sys
-  sys.path = ['/home/isabell/.local/lib/python3.8/site-packages'] + sys.path
+  sys.path = ['/home/isabell/.local/lib/python3.9/site-packages'] + sys.path
 
 ::
 
  [isabell@stardust ~]$ cd mailman-suite
- [isabell@stardust mailman-suite]$ python3.8 manage.py migrate
+ [isabell@stardust mailman-suite]$ python3.9 manage.py migrate
  [...]
- [isabell@stardust mailman-suite]$ python3.8 manage.py collectstatic
+ [isabell@stardust mailman-suite]$ python3.9 manage.py collectstatic
  [...]
- [isabell@stardust mailman-suite]$ python3.8 manage.py createsuperuser
+ [isabell@stardust mailman-suite]$ python3.9 manage.py createsuperuser
  ? Username (leave blank to use 'isabell'): isabell
  ? Email address: isabell@uber.space
  ? Password:
@@ -376,7 +376,7 @@ When Django is configured, we need to rename the example site to match our needs
 ::
 
  [isabell@stardust ~]$ cd mailman-suite
- [isabell@stardust mailman-suite]$ python3.8 manage.py shell
+ [isabell@stardust mailman-suite]$ python3.9 manage.py shell
 
  >>> from django.contrib.sites.models import Site
  >>> site = Site.objects.get(name='example.com')
@@ -404,7 +404,7 @@ To be able to call and execute our Django app, we need to create ``~/uwsgi/apps-
  uid = isabell
  gid = isabell
 
- attach-daemon = python3.8 ./manage.py qcluster
+ attach-daemon = python3.9 ./manage.py qcluster
 
 Generally, it might be necessary to reload *uwsgi* after changing the config change:
 
@@ -479,14 +479,14 @@ As Mailman 3 consists of multiple independent projects, there is no single RSS f
 
 .. code :: bash
 
- [isabell@stardust ~]$ pip3.8 list --outdated --user
+ [isabell@stardust ~]$ pip3.9 list --outdated --user
  [isabell@stardust ~]$
 
 If there are outdated packages, update the mailman packages and their dependencies using:
 
 .. code :: bash
 
- [isabell@stardust ~]$ pip3.8 install --user --upgrade mailman postorius hyperkitty mailman-hyperkitty whoosh uwsgi
+ [isabell@stardust ~]$ pip3.9 install --user --upgrade mailman postorius hyperkitty mailman-hyperkitty whoosh uwsgi
  [isabell@stardust ~]$
 
 .. note:: Even after ``pip --upgrade``, there might be outdated packages. This is the case if mailman's dependencies demand a specific version, e.g. `Django<2.2,>=1.11`, and is nothing to worry about.
@@ -495,7 +495,7 @@ Acknowledgements
 ================
 This guide is based on the `official Mailman 3 installation instructions <http://docs.mailman3.org/en/latest/index.html>`_, the `official Mailman 3 documentation <https://mailman.readthedocs.io/en/latest/README.html>`_ as well as the great guides here at uberlab for :lab:`Django <guide_django.html>` and, of course, :lab:`Mailman 2 <guide_mailman.html>`. Without their previous work, this guide would have not been possible. A special thanks to `luto <https://github.com/luto>`_ for being challenging yet very helpful in overcoming some obstacles!
 
-Tested with Django 2.1.8, HyperKitty 1.2.2, Mailman 3.2.2, Postorius 1.2.4 and uWSGI 2.0.18 on Uberspace 7.2.8.2.
+Tested with Django 4.2.7, HyperKitty 1.2.1, Mailman 3.3.9, Postorius 1.3.10 and uWSGI 2.0.23 on Uberspace 7.2.8.2.
 
 .. _Mailman 3: http://www.mailman3.org/en/latest/
 .. _Mailman: http://www.list.org/


### PR DESCRIPTION
Mailman 3.3.9 is not compatible with Python3.8 anymore, I updated the docs while installing on 3.9