### PR TITLE
[meta] added missing language tags

### DIFF
--- a/source/guide_couchdb.rst
+++ b/source/guide_couchdb.rst
@@ -4,6 +4,7 @@
 
 .. tag:: self-hosting
 .. tag:: database
+.. tag:: Erlang
 
 .. sidebar:: About
 
@@ -144,5 +145,7 @@ Web backend
 .. include:: includes/web-backend.rst
 
 ----
+
+Tested with CouchDB 3.3.3 and Uberspace 7.15.4.0
 
 .. author_list::

--- a/source/guide_ejabberd.rst
+++ b/source/guide_ejabberd.rst
@@ -5,6 +5,7 @@
 .. tag:: XMPP
 .. tag:: Jabber
 .. tag:: Instant Messaging
+.. tag:: Erlang
 
 .. highlight:: console
 

--- a/source/guide_focalboard.rst
+++ b/source/guide_focalboard.rst
@@ -7,6 +7,7 @@
 
 .. tag:: web
 .. tag:: project-management
+.. tag:: golang
 
 .. sidebar:: Logo
 

--- a/source/guide_gancio.rst
+++ b/source/guide_gancio.rst
@@ -5,6 +5,8 @@
 .. tag:: fediverse
 .. tag:: npm
 .. tag:: calendar
+.. tag:: lang-php
+.. tag:: lang-nodejs
 
 .. sidebar:: Logo
 
@@ -20,6 +22,7 @@ Gancio
 .. tag_list::
 
 Gancio_ is a shared agenda for local communities connected to the Fediverse.
+
 ----
 
 .. note:: For this guide you should be familiar with the basic concepts of
@@ -54,7 +57,7 @@ Gancio v1.6.14 is running with node 14=> and 18=<.
   [isabell@stardust ~]$ uberspace tools version use node 18
   Selected Node.js version 18
   The new configuration is adapted immediately. Minor updates will be applied automatically.
-  [isabell@stardust ~]$ 
+  [isabell@stardust ~]$
 
 
 Installation
@@ -80,7 +83,7 @@ Configuration
 =============
 
 
-You will be asked for your database credentials at the setup process when you visit your Gancio instance for the first time. 
+You will be asked for your database credentials at the setup process when you visit your Gancio instance for the first time.
 
 
 Setup daemon
@@ -91,7 +94,7 @@ Create ``~/etc/services.d/gancio.ini`` with the following content:
 .. code-block:: ini
 
  [program:gancio]
- command=%(ENV_HOME)s/bin/gancio 
+ command=%(ENV_HOME)s/bin/gancio
  directory=%(ENV_HOME)s
  autostart=yes
  autorestart=yes
@@ -120,5 +123,9 @@ Updates
   [isabell@stardust ~]$ supervisorctl restart gancio
   gancio: stopped
   gancio: started
+
+----
+
+Tested with Gancio 1.6.14 and Uberspace 7.15.4.0
 
 .. author_list::

--- a/source/guide_influxdb2.rst
+++ b/source/guide_influxdb2.rst
@@ -4,6 +4,8 @@
 .. tag:: database
 .. tag:: metrics
 .. tag:: prometheus
+.. tag:: golang
+.. tag:: rust
 
 .. sidebar:: About
 
@@ -109,7 +111,7 @@ with the following content.
 
 .. include:: includes/supervisord.rst
 
-If it’s not in state RUNNING (after the time set in ``startsecs`` has passed),
+If it's not in state RUNNING (after the time set in ``startsecs`` has passed),
 check your configuration.
 
 Initial Setup

--- a/source/guide_jellyfin.rst
+++ b/source/guide_jellyfin.rst
@@ -6,6 +6,7 @@
 .. tag:: streaming
 .. tag:: mediaplayer
 .. tag:: gallery
+.. tag:: lang-csharp
 
 
 .. sidebar:: About

--- a/source/guide_keycloak.rst
+++ b/source/guide_keycloak.rst
@@ -4,6 +4,7 @@
 
 .. tag:: web
 .. tag:: sso
+.. tag:: lang-java
 
 .. spelling::
     Keycloak

--- a/source/guide_libreoffice.rst
+++ b/source/guide_libreoffice.rst
@@ -12,6 +12,9 @@
 .. tag:: web
 .. tag:: docker
 .. tag:: udocker
+.. tag:: lang-cpp
+.. tag:: lang-java
+.. tag:: lang-python
 
 .. sidebar:: About
 

--- a/source/guide_navidrome.rst
+++ b/source/guide_navidrome.rst
@@ -5,7 +5,7 @@
 .. tag:: mediaplayer
 .. tag:: streaming
 .. tag:: Subsonic
-.. tag:: Go
+.. tag:: golang
 .. tag:: JavaScript
 
 .. sidebar:: Logo

--- a/source/guide_offen.rst
+++ b/source/guide_offen.rst
@@ -9,6 +9,7 @@
 .. tag:: web
 .. tag:: analytics
 .. tag:: privacy
+.. tag:: golang
 
 .. sidebar:: Logo
 

--- a/source/guide_prosody.rst
+++ b/source/guide_prosody.rst
@@ -7,6 +7,7 @@
 .. tag:: Instant Messaging
 .. tag:: Jabber
 .. tag:: XMPP
+.. tag:: lang-lua
 
 .. sidebar:: Logo
 

--- a/source/guide_salt.rst
+++ b/source/guide_salt.rst
@@ -1,6 +1,7 @@
 .. author:: ctr49 <https://github.com/ctr49>
 
 .. tag:: automation
+.. tag:: lang-python
 
 .. highlight:: console
 

--- a/source/guide_shellinabox.rst
+++ b/source/guide_shellinabox.rst
@@ -5,6 +5,7 @@
 .. tag:: web
 .. tag:: console
 .. tag:: ssh
+.. tag:: lang-c
 
 .. sidebar:: About
 

--- a/source/guide_tarsnap.rst
+++ b/source/guide_tarsnap.rst
@@ -3,6 +3,7 @@
 .. author:: Torsten Meyer <https://knodderdachs.de>
 
 .. tag:: backup
+.. tag:: lang-c
 
 .. sidebar:: Logo
 

--- a/source/guide_teamcity.rst
+++ b/source/guide_teamcity.rst
@@ -2,9 +2,9 @@
 
 .. author:: Direnc <direnc99@gmail.com>
 
-.. categorize your guide! refer to the current list of tags: https://lab.uberspace.de/tags
 .. tag:: web
 .. tag:: self-hosting
+.. tag:: lang-java
 
 
 .. sidebar:: About


### PR DESCRIPTION
I updated allmost all guides in the list where the tags where missing (some were already added).

I was unable to find the language of Resilio Sync, Teamspeak, as they are proprietary and only provide binaries.

The Web Key Directory (WKD) doesn't really have a language, as it's only a defined directory structure for PGP files.

I was unable to commit the guides for couchdb and gancio because they are missung the `Tested on Uberspace` part and I'm currently unable to do the tests myself.

The tags would be:

CouchDB

```
.. tag:: Erlang
```

gancio:

```
.. tag:: lang-php
.. tag:: lang-nodejs
```

#1612