### PR TITLE
[baikal] Add config/baikal.yaml to backup

### DIFF
--- a/source/guide_baikal.rst
+++ b/source/guide_baikal.rst
@@ -79,6 +79,7 @@ Backup your ``Specific`` directory, delete everything else in your ``html`` dire
 
  [isabell@stardust ~]$ cd /var/www/virtual/$USER/html/
  [isabell@stardust html]$ cp -r Specific ~
+ [isabell@stardust html]$ cp baikal.yaml ~
  [isabell@stardust html]$ rm -rf * .*
 
 Proceed with the installation steps from here and move back your config file.
@@ -86,6 +87,7 @@ Proceed with the installation steps from here and move back your config file.
 .. code-block:: console
 
  [isabell@stardust html]$ mv ~/Specific ./
+ [isabell@stardust html]$ mv ~/baikal.yaml ./config/
  [isabell@stardust html]$
 
 Finish the update by open isabell.uber.space in your browser.

--- a/source/guide_baikal.rst
+++ b/source/guide_baikal.rst
@@ -73,7 +73,7 @@ Updates
 
 Check Baïkal's `stable releases`_ for the latest versions. You might want to use the `baikal_updates`_ script for doing these checks. If a newer version is available, you should manually update your installation.
 
-Backup your ``Specific`` directory, delete everything else in your ``html`` directory.
+Backup your ``Specific`` directory and the ``baikal.yaml`` config file, delete everything else in your ``html`` directory.
 
 .. code-block:: console
 
@@ -82,7 +82,7 @@ Backup your ``Specific`` directory, delete everything else in your ``html`` dire
  [isabell@stardust html]$ cp baikal.yaml ~
  [isabell@stardust html]$ rm -rf * .*
 
-Proceed with the installation steps from here and move back your config file.
+Proceed with the installation steps from here and move back your config files.
 
 .. code-block:: console
 


### PR DESCRIPTION
A Baïkal setup may break when not backing up `baikal.yaml` due to database encryption not matching. The official [upgrading guide](https://sabre.io/baikal/upgrade/) recommends:

> Keep the whole Specific and config directories intact. Baïkal needs all files, not just the database.