### PR TITLE
Update linters in pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ default_language_version:
 exclude: '\.svg$'
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       # Generall Stuff
       - id: trailing-whitespace
@@ -23,26 +23,26 @@ repos:
       - id: requirements-txt-fixer
   # Prettier (HTML, JS, CSS, Markdown…)
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         # exclude HTML templates (no Jinja2 support)
         exclude: 'source/_templates/.*\.html'
   # YAML
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
   # Python: check syntax
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 6.1.0
     hooks:
       - id: flake8
         args:
           - "--select=F"
   # Python: reorder imports
   - repo: https://github.com/asottile/reorder_python_imports
-    rev: v3.9.0
+    rev: v3.12.0
     hooks:
       - id: reorder-python-imports
         args:
@@ -50,7 +50,7 @@ repos:
           - "--py38-plus"
   # Python: lint with black
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.12.1
     hooks:
       - id: black
         args:


### PR DESCRIPTION
```bash
$ pre-commit autoupdate
[https://github.com/pre-commit/pre-commit-hooks] updating v4.4.0 -> v4.5.0
[https://github.com/pre-commit/mirrors-prettier] updating v3.0.0-alpha.4 -> v4.0.0-alpha.8
[https://github.com/adrienverge/yamllint.git] updating v1.29.0 -> v1.33.0
[https://github.com/pycqa/flake8] updating 6.0.0 -> 6.1.0
[https://github.com/asottile/reorder_python_imports] updating v3.9.0 -> v3.12.0
[https://github.com/psf/black] updating 23.1.0 -> 23.12.1
```
```bash
$ git commit
[INFO] Initializing environment for https://github.com/psf/black.
[INFO] Installing environment for https://github.com/psf/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
trim trailing whitespace.................................................Passed
mixed line ending........................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
check yaml...............................................................Passed
debug statements (python)............................(no files to check)Skipped
fix requirements.txt.................................(no files to check)Skipped
prettier.................................................................Passed
yamllint.................................................................Passed
flake8...............................................(no files to check)Skipped
Reorder python imports...............................(no files to check)Skipped
black................................................(no files to check)Skipped
check guide syntax...................................(no files to check)Skipped
[update_linter 418f9c3] ⬆️ update linters for pre-commit
 1 file changed, 6 insertions(+), 6 deletions(-)
```