### PR TITLE
Fix(NOISSUE): Remove mentioning "nginx" from flask guide

### DIFF
--- a/source/guide_flask.rst
+++ b/source/guide_flask.rst
@@ -202,7 +202,7 @@ Now let's start the service:
 
 
 
-Setup nginx
+Uberspace web backend
 -----------
 
 .. note::

--- a/source/guide_flask.rst
+++ b/source/guide_flask.rst
@@ -203,7 +203,7 @@ Now let's start the service:
 
 
 Uberspace web backend
------------
+---------------------
 
 .. note::
 


### PR DESCRIPTION
The flask guide mentions "Configure nginx". Since the user doesn't interact with nginx directly (I'm not even sure if Uberspace uses nginx, IIRC it's Apache), this was confusing to me.

I propose a change to "Uberspace web backend", as this phrasing is used in the Gitea documentation (which I found super helpful).