### PR TITLE
Use version 3.5.* of pre-commit to avoid InvalidManifestError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e ./authorship
 feedgen==0.9.0
-pre-commit==3.6.*
+pre-commit==3.5.*
 Sphinx==4.4.0
 sphinx-autobuild==2021.3.*
 sphinx-notfound-page==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 -e ./authorship
 feedgen==0.9.0
-pre-commit==2.13.*
+pre-commit==3.6.*
 Sphinx==4.4.0
 sphinx-autobuild==2021.3.*
 sphinx-notfound-page==0.3


### PR DESCRIPTION
Upgrade pre-commit from version 2.13.* to 3.5.* to avoid the following error:

An error has occurred: InvalidManifestError:
==> File /Users/<user>/.cache/pre-commit/repoyg3plrqf/.pre-commit-hooks.yaml ==> At Hook(id='black')
==> At key: stages
==> At index 0
=====> Expected one of commit, commit-msg, manual, merge-commit, post-checkout, post-commit, post-merge, prepare-commit-msg, push but got: 'pre-commit'

Fixes #1733