### PR TITLE
Add specific dependency versions to `requirements.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ by users like you! So, if you'd like to change or add something here, you're
 more than welcome to do so. Have a look at our [contributing guidelines][] to
 learn how. Also, have a look at the [list of guides][] people are looking for!
 
+## Prerequisites
+
+You need to have installed:
+
+-   Python (<= 3.11)
+-   [Enchant library](https://abiword.github.io/enchant/)
+
 ## Development
 
 Pushing for each and every change is fun, but can take some time. To speed up

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,9 @@ Sphinx==4.4.0
 sphinx-autobuild==2021.3.*
 sphinx-notfound-page==0.3
 sphinx-rtd-theme==1.0.*
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.5
 sphinxcontrib-spelling==7.1.0


### PR DESCRIPTION
Without the explicit declaration of this dependencies pip install incompatible versions for Sphinx 4.4.

Added the Enchant library as a prerequisite and that Python version must be less or equal to 3.11. As 3.12 doesn't support the `imp` library anymore ([0]), which is used by Sphinx 4.4.

Fixes #1739

[0]: https://docs.python.org/3.11/library/imp.html