### PR TITLE
Bump Dep Ver for Foundry Guide

### DIFF
--- a/source/guide_foundryvtt.rst
+++ b/source/guide_foundryvtt.rst
@@ -39,13 +39,13 @@ Prerequisites
 
 You need to purchase a `license key <https://foundryvtt.com/purchase/>`_ to run your own version of Foundry Virtual Tabletop.
 
-Foundry requires the use of :manual:`Node.js <lang-nodejs>` 14.
+Foundry requires the use of :manual:`Node.js <lang-nodejs>` 16, though 18 is reccomended.
 
 ::
 
- [isabell@stardust ~]$ uberspace tools version use node 14
- Using 'Node.js' version: '14'
- Selected node version 14
+ [isabell@stardust ~]$ uberspace tools version use node 18
+ Using 'Node.js' version: '18'
+ Selected node version 18
  The new configuration is adapted immediately. Patch updates will be applied automatically.
  [isabell@stardust ~]$
 

--- a/source/guide_foundryvtt.rst
+++ b/source/guide_foundryvtt.rst
@@ -131,6 +131,6 @@ Security
 
 ----
 
-Tested with Foundry 0.8.7, Uberspace 7.1.1
+Tested with Foundry 12.325, Uberspace 7.15.15
 
 .. author_list::


### PR DESCRIPTION
Foundry VTT now requires minimum node version 16, 18 recommended

https://foundryvtt.com/article/requirements/#:~:text=Ability%20to%20run%20Node%2016%2B%2C%20(18%20recommended)