### PR TITLE
Update guide_resilio.rst to 2.8.1

### DIFF
--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -107,7 +107,9 @@ Now go to ``https://<username>.uber.space`` (would be ``https://isabell.uber.spa
 Update Resilio Sync
 ===================
 
-The webinterface will notify you when a new version of Resilio Sync is available. To install the update, download the latest binaries, extract them, and restart the service:
+The webinterface will notify you when a new version of Resilio Sync is available. You can also periodically check the Changelog_.
+
+To install the update, download the latest binaries, extract them, and restart the service:
 
 ::
 
@@ -120,6 +122,7 @@ The webinterface will notify you when a new version of Resilio Sync is available
  [isabell@stardust bin]$
 
 .. _Resilio: https://www.resilio.com
+.. _Changelog: https://help.resilio.com/hc/en-us/articles/206216855-Resilio-Sync-change-log
 
 ----
 

--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -45,7 +45,7 @@ Change into the ``~/bin`` directory, download and extract the latest version of 
 ::
 
  [isabell@stardust ~]$ cd ~/bin
- [isabell@stardust bin]$ wget https://download-cdn.resilio.com/stable/linux-x64/resilio-sync_x64.tar.gz
+ [isabell@stardust bin]$ wget https://download-cdn.resilio.com/stable/linux/x64/0/resilio-sync_x64.tar.gz
  [isabell@stardust bin]$ tar --gzip --extract --file resilio-sync_x64.tar.gz
  [isabell@stardust bin]$ rm resilio-sync_x64.tar.gz
  [isabell@stardust bin]$
@@ -112,7 +112,7 @@ The webinterface will notify you when a new version of Resilio Sync is available
 ::
 
  [isabell@stardust ~]$ cd ~/bin
- [isabell@stardust bin]$ wget https://download-cdn.resilio.com/stable/linux-x64/resilio-sync_x64.tar.gz
+ [isabell@stardust bin]$ wget https://download-cdn.resilio.com/stable/linux/x64/0/resilio-sync_x64.tar.gz
  [isabell@stardust bin]$ supervisorctl stop resilio-sync
  [isabell@stardust bin]$ tar --gzip --extract --overwrite --file resilio-sync_x64.tar.gz
  [isabell@stardust bin]$ rm resilio-sync_x64.tar.gz
@@ -123,6 +123,6 @@ The webinterface will notify you when a new version of Resilio Sync is available
 
 ----
 
-Tested with Resilio Sync 2.5.12, Uberspace 7.1.4.0
+Tested with Resilio Sync 2.8.0, Uberspace 7.15.15
 
 .. author_list::

--- a/source/guide_resilio.rst
+++ b/source/guide_resilio.rst
@@ -123,6 +123,6 @@ The webinterface will notify you when a new version of Resilio Sync is available
 
 ----
 
-Tested with Resilio Sync 2.8.0, Uberspace 7.15.15
+Tested with Resilio Sync 2.8.1, Uberspace 7.15.15
 
 .. author_list::


### PR DESCRIPTION
Resilio Sync recently pushed an update (so they are not dead, yay!).

Download URLs have changed, so these needed adjustments.