### PR TITLE
Update php url in guide_moodle.rst

### DIFF
--- a/source/guide_moodle.rst
+++ b/source/guide_moodle.rst
@@ -31,7 +31,7 @@ Moodle_ Moodle is an acronym for "Modular Object-Oriented Dynamic Learning Envir
 
   * :manual:`MySQL <database-mysql>`
   * :manual:`cron <daemons-cron>`
-  * :manual:`php <php-lang>`
+  * :manual:`php <lang-php>`
   * :manual:`domains <web-domains>`
 
 License


### PR DESCRIPTION
The PHP link wasn't working as it was pointing to php-lang, but the actual URL is lang-php.