### PR TITLE
Update guide_nextcloud.rst

### DIFF
--- a/source/guide_nextcloud.rst
+++ b/source/guide_nextcloud.rst
@@ -83,7 +83,7 @@ OPcache caches script bytecode in shared memory, so scripts need not to be loade
  opcache.enable_cli=1
  opcache.interned_strings_buffer=16
  opcache.max_accelerated_files=10000
- opcache.memory_consumption=128
+ opcache.memory_consumption=256
  opcache.save_comments=1
  opcache.revalidate_freq=1
 


### PR DESCRIPTION
As of Nextcloud Hub 9 (core version 30), values > 128 are expected for opcache.memory_consumption.