### PR TITLE
fix actual guide, include bcrypt downgrade

### DIFF
--- a/source/guide_actual.rst
+++ b/source/guide_actual.rst
@@ -17,13 +17,6 @@ Actual
 
 .. tag_list::
 
-.. error::
-
-  This guide seems to be **broken** for the Actual versions v24.7.0 and higher, we would be
-  happy if you want to work on a solution and create a Pull Request. The most recent working version is v24.6.0.
-  See also the related issue: https://github.com/Uberspace/lab/issues/1802
-
-
 `Actual Budget`_ is a super fast and privacy-focused app for managing your finances. At its heart is the well proven and much loved Envelope Budgeting methodology. It features multi-device sync, and optional end-to-end encryption.
 
 You can find the source code on `Git Hub`_.
@@ -64,11 +57,29 @@ Now navigate to the directory where you cloned the project.
   [isabell@stardust ~]$ cd actual-server
   [isabell@stardust actual]$
 
-Install all the dependencies using `yarn`
+By default, current versions of Actual depend on a cryptography library called bcrypt in version 5.1.1 or later.
+This versions is not compatible with Uberspace v7 and needs to be downgraded to 5.1.0.
+To do so, open `package.json` in your favorite editor and replace
+
+.. code-block:: json
+
+  "bcrypt": "^5.1.1",
+
+by
+
+.. code-block:: json
+
+  "bcrypt": "5.1.0",
+
+in the `dependencies` section.
+
+Install all the dependencies using `yarn`.
+Be sure to pass the option `--refresh-lockfile`,
+so that the changes to `packages.json` are taken into account.
 
 ::
 
-  [isabell@stardust actual]$ yarn install
+  [isabell@stardust actual]$ yarn install --refresh-lockfile
   […]
   ➤ YN0000: └ Completed in 1m 50s
   ➤ YN0000: · Done with warnings in 2m 2s
@@ -110,21 +121,28 @@ Updates
 
 When a new Actual release is published, follow these steps to update:
 
-1. Stop the server if it’s running using ``supervisorctl stop actual``.
-2. Run ``git pull`` from the directory you cloned the project into. This will download the latest server code.
-3. Run ``yarn install`` from that same directory. This will download the latest web client code, along with any updated dependencies for the server.
-4. Restart the server by running ``supervisorctl start actual``.
+1. Stop the server if it's running using ``supervisorctl stop actual``.
+2. Discard the changes to `packages.json` and `yarn.lock` using ``git checkout packages.json yarn.lock``
+3. Run ``git pull`` from the directory you cloned the project into. This will download the latest server code.
+4. Replace the version of the bcrypt dependency as described above.
+5. Run ``yarn install --refresh-lockfile`` from that same directory.
+This will download the latest web client code, along with any updated dependencies for the server.
+6. Restart the server by running ``supervisorctl start actual``.
 
 .. code-block:: bash
 
   [isabell@stardust ~]$ supervisorctl stop actual
   actual: stopped
   [isabell@stardust ~]$ cd ~/actual-server
+  [isabell@stardust actual-server]$ git checkout packages.json yarn.lock
+  […]
   [isabell@stardust actual-server]$ git pull
   remote: Enumerating objects: 4, done.
   remote: Counting objects: 100% (4/4), done.
   […]
-  [isabell@stardust actual-server]$ yarn install
+  [apply changes to `packages.json`]
+  […]
+  [isabell@stardust actual-server]$ yarn install --refresh-lockfile
   […]
   [isabell@stardust actual-server]$ supervisorctl start actual
   actual: started
@@ -136,6 +154,6 @@ When a new Actual release is published, follow these steps to update:
 
 ----
 
-Tested with Actual 23.12.0, Uberspace 7.15.4
+Tested with Actual 24.10.1, Uberspace 7.16.2
 
 .. author_list::


### PR DESCRIPTION
Resolves #1802

Actual in its current version depends on a too new version of bcrypt not compatible with Uberspace v7. Can still be used by downgrading the bcrypt dependency.