### PR TITLE
Add missing closing tag

### DIFF
--- a/source/guide_beehive.rst
+++ b/source/guide_beehive.rst
@@ -32,7 +32,7 @@ agents.
 
 .. note:: For this guide you should be familiar with the basic concepts of
 
-  * :manual:`Go <lang-golang`
+  * :manual:`Go <lang-golang>`
   * :manual:`Supervisord <daemons-supervisord>`
   * :manual:`Domains <web-domains>`
 


### PR DESCRIPTION
The guid for Beehive was missing a closing tag in the first note box.