### PR TITLE
update enchant documentation link (fixes #1877)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ learn how. Also, have a look at the [list of guides][] people are looking for!
 You need to have installed:
 
 -   Python (<= 3.11)
--   [Enchant library](https://abiword.github.io/enchant/)
+-   [Enchant library](https://rrthomas.github.io/enchant/)
 
 ## Development
 


### PR DESCRIPTION
enchant documentation [moved](https://github.com/AbiWord/enchant/commit/7e4d87ba2d2959dc0c3386ba53880f21e600cf1c) to a [new home](https://rrthomas.github.io/enchant/)