### PR TITLE
[Vaultwarden] Hint at problems with default Web Security Headers

### DIFF
--- a/source/guide_vaultwarden.rst
+++ b/source/guide_vaultwarden.rst
@@ -123,6 +123,10 @@ Setup web backend
 
 If you want to use a subdomain refer to the :manual:`web-backend manual <web-backends>`.
 
+.. note::
+    The default nginx config defines `X-Frame-Options: SAMEORIGIN` for all web backends. This may cause compatibility issues with the 2-step login feature and desktop/mobile clients as well as notifications on websockets.
+    If you encounter these issues, you may want to consider suppressing that header for relevant paths i. e. /*connector.html, /notifications/hub, /notifications/anonymous-hub, refer to the :manual:`web-security-headers manual<web-security-headers>`.
+
 Setup web vault
 ---------------
 


### PR DESCRIPTION
The guide should be amended by a hint towards uberspaces default Web Security Headers which might interfere with 2-step login and or notifications.

Refer to https://github.com/dani-garcia/vaultwarden/blob/8d1df08/src/util.rs lines 38 and 73

Also see #1901