### PR TITLE
Remove copypaste leftover

### DIFF
--- a/source/guide_goatcounter.rst
+++ b/source/guide_goatcounter.rst
@@ -117,11 +117,6 @@ Updates
 
 When an update is available download a new release from the release page and follow the update instructions on the goatcounter-github_.
 
-::
-
- [isabell@stardust ~]$ pip3 install --user --upgrade isso
-
-
 .. _goatcounter: https://www.goatcounter.com/
 .. _goatcounter-github: https://github.com/arp242/goatcounter
 


### PR DESCRIPTION
Remove a block about suggesting pip upgrade isso which looks as if it was copied from the isso page.