### PR TITLE
Update license hint for forgejo

### DIFF
--- a/source/guide_forgejo.rst
+++ b/source/guide_forgejo.rst
@@ -22,7 +22,7 @@ Forgejo
 .. tag_list::
 
 Forgejo_ is a self-hosted Git service with a functionality similar to GitHub, GitLab and BitBucket.
-It's a hard-fork of Gitea_ and uses the same MIT licence_. Like most applications written in Go it's easy to install.
+It's a hard-fork of Gitea_, which changed_ it's licensing in August 2024 from MIT to the GNU GPL v2 licence_. Like most applications written in Go it's easy to install.
 
 ----
 
@@ -348,6 +348,7 @@ Now we have to append the config file ``$FORGEJO_HOME/custom/conf/app.ini`` with
 .. _feed: https://forgejo.org/releases/rss.xml
 .. _releases: https://codeberg.org/forgejo/forgejo/releases
 .. _licence: https://codeberg.org/forgejo/forgejo/raw/branch/forgejo/LICENSE
+.. _changed: https://forgejo.org/2024-08-gpl/
 .. _dashboard: https://uberspace.de/dashboard/authentication
 
 ----


### PR DESCRIPTION
The forgejo installation page still mentions the MIT license, but Forgejo changed it a year ago. The link itself already reflected that, but not the text itself, this fixes it :)