### PR TITLE
[PostgreSQL] Add resource configuration options

### DIFF
--- a/source/guide_postgresql.rst
+++ b/source/guide_postgresql.rst
@@ -195,6 +195,26 @@ Consider using only unix sockets if possible.
                                         # (change requires restart)
  #unix_socket_group = ''                # (change requires restart)
 
+Resource Configuration
+------------------------
+
+With the default settings PostgreSQL can consume quite a lot of resources.
+Especially the number of open file handles can become a problem. To reduce the
+resource consumption, the following settings can be lowered:
+
+.. code-block:: ini
+
+  max_files_per_process = 64
+  max_worker_processes = 4
+  max_parallel_workers = 2
+
+Additionally, the number of connections can be reduced:
+
+.. warning:: If you lower the number of allowed connections, make sure to adjust your client’s connection settings as well. Otherwise, it might fail to start!
+
+.. code-block:: ini
+
+  max_connections = 20
 
 Logging
 -------


### PR DESCRIPTION
Suggest adjustments to the PostgreSQL configuration that will limit the resource consumption, especially open file handles.

Without these adjustments, a Dendrite instance I operate does not work correctly as too many files are open. Dendrite itself does not open many files but PostgreSQL can easily open 3000 file handles. I know the suggested values are quite low but they will reduce the open file handles greatly to about 1000 (depending on the load, of course). With these changes applied, the Dendrite instance works fine.

I use this command to determine the open file handles for PostgreSQL:

```bash
/usr/sbin/lsof | grep postgres | wc -l
```