### PR TITLE
Update guide_forgejo.rst - mysql host

### DIFF
--- a/source/guide_forgejo.rst
+++ b/source/guide_forgejo.rst
@@ -137,6 +137,7 @@ Create a config file ``$FORGEJO_HOME/custom/conf/app.ini`` with the content of t
 
   [database]
   DB_TYPE  = mysql
+  HOST     = 127.0.0.1:3306
   NAME     = isabell_forgejo
   USER     = isabell
   PASSWD   = <MySQL_PASSWORD>


### PR DESCRIPTION
The hostname is necessary in order to make the database initialization work. Tested with version 12.0.1