### PR TITLE
Add minimal devcontainer configuration w/ README notes for usage in VS Code

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "uberspace-lab",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/python:1": {
+            "version": "3.11",
+            "installTools": true
+        },
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "upgradePackages": true
+        }
+    },
+
+    // Use 'forwardPorts' to expose the Sphinx Development Server
+    "forwardPorts": [8000],
+    "portsAttributes": {
+        "8000": {
+            "label": "Sphinx Development Server"
+        }
+    },
+
+    // Use 'onCreateCommand' to run commands INSIDE the container IMMEDIATELY after the container is created. Runs only once.
+    "onCreateCommand": "sudo apt update && sudo apt install -y libenchant-2-2 libenchant-2-dev enchant-2 build-essential",
+
+    // Use 'postCreateCommand' to run commands INSIDE the container AFTER the container is created. Runs only once.
+    "postCreateCommand": "make setup"
+}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ learn how. Also, have a look at the [list of guides][] people are looking for!
 
 ## Prerequisites
 
-You need to have installed:
+**Note:** When using VS Code with the [devcontainer](https://containers.dev/), you only need to have [Docker](https://docs.docker.com/desktop/) installed.
+
+Simply open the repository in VS Code and press `F1` to open the command palette, then select `Remote-Containers: Reopen in Container` to open the repository in a container.
+
+The devcontainer will have all the necessary dependencies installed, and will automatically run the initial setup.
+
+Generally, you need to have installed:
 
 -   Python (<= 3.11)
 -   [Enchant library](https://rrthomas.github.io/enchant/)


### PR DESCRIPTION
Don't like having to care about local dev env requirements, especially with python-venvs involved - so I wrote a quick dev container setup.

It covers all requirements and dependencies, should apply to the [Uberspace/manual](https://github.com/Uberspace/manual) repo as well.

Advantage for working on the repo: No setup actions necessary.

---

_<small>No LLMs have been consulted in the work</small>_