### PR TITLE
Update guide_pretix.rst to include a section on redis

### DIFF
--- a/source/guide_pretix.rst
+++ b/source/guide_pretix.rst
@@ -126,7 +126,7 @@ Now you need to set up the configuration, create the file ``~/.pretix.cfg`` and 
 
     [redis]
     # use the Redis UNIX socket; pick a DB number you reserve for pretix caches/sessions
-    location=unix:///home/qhc/.redis/sock?db=1
+    location=unix:///home/isabell/.redis/sock?db=1
     # store Django sessions in Redis too (recommended)
     sessions=true
 


### PR DESCRIPTION
When checking the system health via the proposed GET request (see here: https://docs.pretix.eu/self-hosting/maintenance/#uptime-monitoring), it returned a message that "Cache was not available".  I checked the pretix docs and adapted the section on redis in the .pretix.cfg