### PR TITLE
vikunja: Adapt to new download path

### DIFF
--- a/source/guide_vikunja.rst
+++ b/source/guide_vikunja.rst
@@ -59,9 +59,9 @@ Find the latest version of Vikunja on the releases_ page and download it:
 
 .. code-block:: console
 
-  [isabell@stardust ~]$ VERSION=0.24.6
+  [isabell@stardust ~]$ VERSION=2.2.0
   [isabell@stardust ~]$ mkdir ~/vikunja
-  [isabell@stardust ~]$ wget -O ~/vikunja/vikunja.zip "https://dl.vikunja.io/vikunja/$VERSION/vikunja-v$VERSION-linux-amd64-full.zip"
+  [isabell@stardust ~]$ wget -O ~/vikunja/vikunja.zip "https://dl.vikunja.io/vikunja/v$VERSION/vikunja-v$VERSION-linux-amd64-full.zip"
   [...]
   Saving to: ‘/home/isabell/vikunja/vikunja.zip’
 


### PR DESCRIPTION
Since Vikunja 1.0.0 the download path changed slightly.

With this change the example version is updated to the latest version, so that we have a current version present that uses the new path.