### PR TITLE
Update cp command to copy all contents from static.dist

### DIFF
--- a/source/guide_pretix.rst
+++ b/source/guide_pretix.rst
@@ -273,7 +273,7 @@ Then re-run the Initialize database steps and restart the service like so:
  [isabell@stardust ~]$ python3.11 -m pretix migrate
  [isabell@stardust ~]$ python3.11 -m pretix rebuild
  [isabell@stardust ~]$ python3.11 -m pretix updateassets
- [usabell@stardust ~]$ cp -r ~/.local/lib/python3.11/site-packages/pretix/static.dist /var/www/virtual/isabell/html/static
+ [usabell@stardust ~]$ cp -r ~/.local/lib/python3.11/site-packages/pretix/static.dist/. /var/www/virtual/isabell/html/static/
  [isabell@stardust ~]$ supervisorctl restart pretix
  [isabell@stardust ~]$
 


### PR DESCRIPTION
The previous command copied the entire static.dist/ folder into the static/ folder, which is not what was intended. 

The new cp command now correctly copies the **contents** of the static.dist/ folder into the static/ folder.