### PR TITLE
Changed command in services.d/filebrowser.ini 

### DIFF
--- a/source/guide_filebrowser.rst
+++ b/source/guide_filebrowser.rst
@@ -104,7 +104,7 @@ Create ``~/etc/services.d/filebrowser.ini`` with the following content:
 
  [program:filebrowser]
  directory=%(ENV_HOME)s/filebrowser
- command=filebrowser
+ command=%(ENV_HOME)s/filebrowser/filebrowser
  startsecs=30
  autostart=yes
 


### PR DESCRIPTION
Fixed the supervisor start command for filebrowser by using the absolute binary path instead of relying on PATH resolution. This ensures the service starts correctly under Uberspace supervisord.