### PR TITLE
Matrix Synapse: Additional information, important for client login

### DIFF
--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -205,7 +205,6 @@ Create the file ``/var/www/virtual/$USER/example.org/.well-known/matrix/server``
 In order to tell Matrix clients where to sign in, you'll need to create another file ``/var/www/virtual/$USER/example.org/.well-known/matrix/client`` with the following content. Please note that the content differs slightly from the previous file.
 
 .. code-block:: json
-  :emphasize-lines: 2
   {
     "m.homeserver": { "base_url": "https://matrix.example.org" }
   }

--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -202,6 +202,14 @@ Create the file ``/var/www/virtual/$USER/example.org/.well-known/matrix/server``
     "m.server": "matrix.example.org:443"
   }
 
+In order to tell Matrix clients where to sign in, you'll need to create another file ``/var/www/virtual/$USER/example.org/.well-known/matrix/client`` with the following content. Please note that the content differs slightly from the previous file.
+
+.. code-block:: json
+  :emphasize-lines: 2
+  {
+    "m.homeserver": { "base_url": "https://matrix.example.org" }
+  }
+
 This has to be made available under ``example.org/.well-known/matrix`` via the web backend:
 
 .. code-block:: console

--- a/source/guide_synapse.rst
+++ b/source/guide_synapse.rst
@@ -204,10 +204,14 @@ Create the file ``/var/www/virtual/$USER/example.org/.well-known/matrix/server``
 
 In order to tell Matrix clients where to sign in, you'll need to create another file ``/var/www/virtual/$USER/example.org/.well-known/matrix/client`` with the following content. Please note that the content differs slightly from the previous file.
 
+
 .. code-block:: json
+  :emphasize-lines: 2
+
   {
     "m.homeserver": { "base_url": "https://matrix.example.org" }
   }
+
 
 This has to be made available under ``example.org/.well-known/matrix`` via the web backend:
 


### PR DESCRIPTION
Hi,

I struggled with most matrix clients - Element/SchildiChat and NeoChat namely - to log in. Element gave no hint, but Element X failed with an "404 no json content" error. I found this error in my access _log and learned, that most clients need a .well-known client json, like the server json for federation.
So here is this bit of additional information, which should make it easier to get Synapse up and running.

Cheers
wertziop
